### PR TITLE
Add two ESLint spacing rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
 		'eol-last': ['error'],
 		'indent': ['error', 'tab', { 'SwitchCase': 1 }],
 		'jsx-quotes': ['error', 'prefer-single'],
+		'key-spacing': ['error'],
 		'keyword-spacing': ['error'],
 		'max-statements-per-line': ['error'],
 		'no-floating-decimal': ['error'],
@@ -47,6 +48,7 @@ module.exports = {
 		'space-before-blocks': ['error'],
 		'space-before-function-paren': ['error', { 'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always' }],
 		'space-infix-ops': 'error',
+		'@typescript-eslint/type-annotation-spacing': ['error'],
 		'yoda': 'error'
 	},
 	overrides: [


### PR DESCRIPTION
I added two rules:

`key-spacing` that specifies no space before an object colon and one after it
`type-annotation-spacing` that specifies the same thing but for TS typings