### PR TITLE
Remove usage of parse-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ or
 yarn add @thornbill/jellyfin-sdk
 ```
 
+### React Native
+
+The generated Axios client used in this library depends on `URL` and `URLSearchParams` to be available on the global scope.
+React Native only includes incomplete implementations for these classes, so a polyfill is required.
+[React Native URL Polyfill](https://github.com/charpeni/react-native-url-polyfill) should be a good solution fo this.
+
 ## Usage
 
 ```js

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,19 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-	preset: 'ts-jest',
-	runner: 'groups',
 	testEnvironment: 'node',
+	runner: 'groups',
+
+	// normalize-url exports an ES module so we need to transform js files
+	// and change the ignore pattern so it is transformed
+	preset: 'ts-jest/presets/js-with-ts',
+	globals: {
+		'ts-jest': {
+			tsconfig: { allowJs: true }
+		}
+	},
+	transformIgnorePatterns: [ '/node_modules/(?!(normalize-url)/)' ],
+
+	// Coverage options
 	collectCoverageFrom: [ 'src/**' ],
 	coveragePathIgnorePatterns: [ '__helpers__', 'generated-client' ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1177,12 +1177,6 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
-    "@types/url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-KtQLad12+4T/NfSxpoDhmr22+fig3T7/08QCgmutYA6QSznSRmEtuL95GrhVV40/0otTEdFc+etRcCTqhh1q5Q==",
-      "dev": true
-    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -5087,6 +5081,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.0.2.tgz",
+      "integrity": "sha512-HC9c6eHqxmiR6sL9DKt9ttLkiLaI1jytdkJMGAEvkLAAdlOi99kR7UMWWWRrwjucuFabaau4ZuvP1Zv+6PpDjA=="
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -5455,11 +5454,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5587,11 +5581,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.20.0",
@@ -6255,15 +6244,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.9.2",
-    "@types/url-parse": "^1.4.4",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "eslint": "^7.32.0",
@@ -47,6 +46,6 @@
   "dependencies": {
     "axios": "^0.22.0",
     "compare-versions": "^3.6.0",
-    "url-parse": "^1.5.3"
+    "normalize-url": "^7.0.2"
   }
 }

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import Url from 'url-parse';
-
 import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl } from '..';
 
 /**
@@ -16,7 +14,7 @@ import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, c
 describe('Url', () => {
 	describe('copyUrl()', () => {
 		it('should return a copy', () => {
-			const original = new Url('https://example.com');
+			const original = new URL('https://example.com');
 			const copy = copyUrl(original);
 
 			expect(copy).not.toBe(original);
@@ -43,7 +41,7 @@ describe('Url', () => {
 	describe('parseUrl()', () => {
 		it('should parse a url string', () => {
 			const url = parseUrl('https://example.com');
-			expect(url).toBeInstanceOf(Url);
+			expect(url).toBeInstanceOf(URL);
 			expect(url.toString()).toBe('https://example.com/');
 		});
 

--- a/src/utils/address-candidates.ts
+++ b/src/utils/address-candidates.ts
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import Url from 'url-parse';
-
 import { HTTPS_PORT, HTTP_PORT, HTTP_PROTOCOL, HTTPS_PROTOCOL, parseUrl, copyUrl, getDefaultPort } from './url';
 
 /** The default http port for Jellyfin servers. */
@@ -19,7 +17,7 @@ export const JF_HTTPS_PORT = 8920;
  * @param url The url to evaluate.
  * @returns The score.
  */
-function getScore(url: Url): number {
+function getScore(url: URL): number {
 	let score = 0;
 
 	// Prefer secure connections
@@ -52,36 +50,32 @@ function getScore(url: Url): number {
  * @returns A list of potential server addresses.
  */
 export function getAddressCandidates(input: string): Array<string> {
-	const candidates: Array<Url> = [];
+	const candidates: Array<URL> = [];
 
 	try {
 		const url = parseUrl(input);
 		candidates.push(url);
 
 		if (url.protocol === HTTP_PROTOCOL) {
-			candidates.push(
-				copyUrl(url)
-					.set('protocol', HTTPS_PROTOCOL)
-			);
+			const copy = copyUrl(url);
+			copy.protocol = HTTPS_PROTOCOL;
+			candidates.push(copy);
 		}
 
 		candidates
 			.filter(val => !val.port || val.port === getDefaultPort(val.protocol).toString())
 			.forEach(val => {
 				if (val.protocol === HTTP_PROTOCOL) {
-					candidates.push(
-						copyUrl(val)
-							.set('port', JF_HTTP_PORT.toString())
-					);
+					const copy = copyUrl(val);
+					copy.port = JF_HTTP_PORT.toString();
+					candidates.push(copy);
 				} else if (val.protocol === HTTPS_PROTOCOL) {
-					candidates.push(
-						copyUrl(val)
-							.set('port', JF_HTTP_PORT.toString())
-					);
-					candidates.push(
-						copyUrl(val)
-							.set('port', JF_HTTPS_PORT.toString())
-					);
+					let copy = copyUrl(val);
+					copy.port = JF_HTTP_PORT.toString();
+					candidates.push(copy);
+					copy = copyUrl(val);
+					copy.port = JF_HTTPS_PORT.toString();
+					candidates.push(copy);
 				}
 			});
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import Url from 'url-parse';
+import normalizeUrl from 'normalize-url';
 
 /** The http protocol string. */
 export const HTTP_PROTOCOL = 'http:';
@@ -19,12 +19,12 @@ export const HTTP_PORT = 80;
 export const HTTPS_PORT = 443;
 
 /**
- * Copies a Url instance.
- * @param original The original Url.
- * @returns A copy of the original Url.
+ * Copies a URL instance.
+ * @param original The original URL.
+ * @returns A copy of the original URL.
  */
-export function copyUrl(original: Url): Url {
-	return new Url(original.toString());
+export function copyUrl(original: URL): URL {
+	return new URL(original.toString());
 }
 
 /**
@@ -43,23 +43,12 @@ export function getDefaultPort(protocol: string): number {
  * @param input A string representing a url.
  * @returns The Url object.
  */
-export function parseUrl(input: string): Url {
-	if (!input || !input.trim()) {
+export function parseUrl(input: string): URL {
+	if (!input?.trim()) {
 		throw new Error('Input is required');
 	}
 
-	let url = new Url(input);
-
-	if (!url.protocol) {
-		url.set('protocol', HTTP_PROTOCOL);
-		// HACK: Not all properties of the url are being updated when the protocol
-		// is set, so we need to re-parse it manually.
-		url = copyUrl(url);
-	}
-
-	if (!url.hostname) {
-		throw new Error(`Could not parse hostname for ${input}`);
-	}
-
-	return url;
+	return new URL(
+		normalizeUrl(input, { stripWWW: false })
+	);
 }


### PR DESCRIPTION
The generated client depends on the `URL` and `URLSearchParams` globals to be available, so there is really no point in keeping `url-parse`...