### PR TITLE
Export generated models

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,7 @@ import globalInstance, { AxiosInstance, AxiosResponse } from 'axios';
 
 import { ActivityLogApi, ApiKeyApi, ArtistsApi, AudioApi, AuthenticationResult, BrandingApi, ChannelsApi, CollectionApi, Configuration, ConfigurationApi, DashboardApi, DevicesApi, DisplayPreferencesApi, DlnaApi, DlnaServerApi, DynamicHlsApi, EnvironmentApi, FilterApi, GenresApi, HlsSegmentApi, ImageApi, ImageByNameApi, ImageType, InstantMixApi, ItemLookupApi, ItemRefreshApi, ItemsApi, ItemUpdateApi, LibraryApi, LibraryStructureApi, LiveTvApi, LocalizationApi, MediaInfoApi, MoviesApi, MusicGenresApi, NotificationsApi, PackageApi, PersonsApi, PlaylistsApi, PlaystateApi, PluginsApi, QuickConnectApi, RemoteImageApi, ScheduledTasksApi, SearchApi, SessionApi, StartupApi, StudiosApi, SubtitleApi, SuggestionsApi, SyncPlayApi, SystemApi, TimeSyncApi, TrailersApi, TvShowsApi, UniversalAudioApi, UserApi, UserLibraryApi, UserViewsApi, VideoAttachmentsApi, VideoHlsApi, VideosApi, YearsApi } from './generated-client';
 import { ClientInfo, DeviceInfo } from './models';
-import { ImageRequestParameters } from './models/image-request-parameters';
+import { ImageRequestParameters } from './models/api/image-request-parameters';
 import { getAuthorizationHeader } from './utils';
 
 // HACK: Axios does not export types for axios/lib. This is a workaround.

--- a/src/models/api/image-request-parameters.ts
+++ b/src/models/api/image-request-parameters.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ImageFormat } from '../generated-client';
+import { ImageFormat } from '../../generated-client';
 
 /**
  * Interface representing supported request parameters for the getItemImage API.

--- a/src/models/api/index.ts
+++ b/src/models/api/index.ts
@@ -4,9 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export * as api from './api';
+export * from '../../generated-client/models';
 
-export * from './client-info';
-export * from './device-info';
-export * from './recommended-server-info';
-export * from './recommended-server-issue';
+export * from './image-request-parameters';


### PR DESCRIPTION
Exports the generated client models and `ImageRequestParameters` model under `models.api`.

Fixes #120 