### PR TITLE
Add enums for BaseItemKind and ItemSortBy

### DIFF
--- a/src/models/api/base-item-kind.ts
+++ b/src/models/api/base-item-kind.ts
@@ -1,0 +1,54 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// NOTE: This should be included in the generated models in the 10.8 openapi spec
+
+/**
+ * An enum representing the possible base item types.
+ * References: https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Data/Enums/BaseItemKind.cs
+ * @export
+ * @enum {string}
+ */
+
+export enum BaseItemKind {
+	AggregateFolder = 'AggregateFolder',
+	Audio = 'Audio',
+	AudioBook = 'AudioBook',
+	BasePluginFolder = 'BasePluginFolder',
+	Book = 'Book',
+	BoxSet = 'BoxSet',
+	Channel = 'Channel',
+	ChannelFolderItem = 'ChannelFolderItem',
+	CollectionFolder = 'CollectionFolder',
+	Episode = 'Episode',
+	Folder = 'Folder',
+	Genre = 'Genre',
+	ManualPlaylistsFolder = 'ManualPlaylistsFolder',
+	Movie = 'Movie',
+	LiveTvChannel = 'LiveTvChannel',
+	LiveTvProgram = 'LiveTvProgram',
+	MusicAlbum = 'MusicAlbum',
+	MusicArtist = 'MusicArtist',
+	MusicGenre = 'MusicGenre',
+	MusicVideo = 'MusicVideo',
+	Person = 'Person',
+	Photo = 'Photo',
+	PhotoAlbum = 'PhotoAlbum',
+	Playlist = 'Playlist',
+	PlaylistsFolder = 'PlaylistsFolder',
+	Program = 'Program',
+	Recording = 'Recording',
+	Season = 'Season',
+	Series = 'Series',
+	Studio = 'Studio',
+	Trailer = 'Trailer',
+	TvChannel = 'TvChannel',
+	TvProgram = 'TvProgram',
+	UserRootFolder = 'UserRootFolder',
+	UserView = 'UserView',
+	Video = 'Video',
+	Year = 'Year'
+}

--- a/src/models/api/index.ts
+++ b/src/models/api/index.ts
@@ -6,4 +6,6 @@
 
 export * from '../../generated-client/models';
 
+export * from './base-item-kind';
 export * from './image-request-parameters';
+export * from './item-sort-by';

--- a/src/models/api/item-sort-by.ts
+++ b/src/models/api/item-sort-by.ts
@@ -1,0 +1,42 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * An enum representing the item sort by options.
+ * References: https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Model/Querying/ItemSortBy.cs
+ * @export
+ * @enum {string}
+ */
+
+export enum ItemSortBy {
+	AiredEpisodeOrder = 'AiredEpisodeOrder',
+	AirTime = 'AirTime',
+	Album = 'Album',
+	AlbumArtist = 'AlbumArtist',
+	Artist = 'Artist',
+	CommunityRating = 'CommunityRating',
+	CriticRating = 'CriticRating',
+	DateCreated = 'DateCreated',
+	DateLastContentAdded = 'DateLastContentAdded',
+	DatePlayed = 'DatePlayed',
+	IsFavoriteOrLiked = 'IsFavoriteOrLiked',
+	IsFolder = 'IsFolder',
+	IsPlayed = 'IsPlayed',
+	IsUnplayed = 'IsUnplayed',
+	Name = 'Name',
+	OfficialRating = 'OfficialRating',
+	PlayCount = 'PlayCount',
+	PremiereDate = 'PremiereDate',
+	ProductionYear = 'ProductionYear',
+	Random = 'Random',
+	Runtime = 'Runtime',
+	SeriesDatePlayed = 'SeriesDatePlayed',
+	SeriesSortName = 'SeriesSortName',
+	SortName = 'SortName',
+	StartDate = 'StartDate',
+	Studio = 'Studio',
+	VideoBitRate = 'VideoBitRate'
+}


### PR DESCRIPTION
Adds enums for parameters frequently used in queries that are not included in the exported models.

Fixes #121 