### PR TITLE
Move output directory to lib

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist
 generated-client
+lib
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 dist
+lib
 node_modules

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "keywords": [
     "jellyfin"
   ],
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES5",
     "declaration": true,
     "noImplicitAny": true,
-    "outDir": "dist"
+    "outDir": "lib"
   },
   "typedocOptions": {
     "entryPoints": [


### PR DESCRIPTION
This comes down to personal preference, but I think `lib` makes for a better import path than `dist`.