### PR TITLE
Remove unnecessary exports

### DIFF
--- a/src/models/api/index.ts
+++ b/src/models/api/index.ts
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export * from '../../generated-client/models';
-
 export * from './base-item-kind';
 export * from './image-request-parameters';
 export * from './item-sort-by';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export * as api from './api';
-
 export * from './client-info';
 export * from './device-info';
 export * from './recommended-server-info';


### PR DESCRIPTION
These exports really didn't improve the developer experience like I hoped... it just made things confusing to have the same models exported via different paths.