### PR TITLE
Fix tree-shaking of the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ A TypeScript SDK for Jellyfin.
 
 > Warning: This project is under active development, so API changes may occur.
 
+## Breaking Changes
+
+### v0.5.0
+
+* Build directory is now `lib` instead of `dist`.
+  Any imports used that were previously in `dist` will need updated.
+  [#147](https://github.com/thornbill/jellyfin-sdk-typescript/pull/147)
+* Duplicated exports were removed.
+  Any imports may need updated if you referenced one of the duplicates.
+  [#148](https://github.com/thornbill/jellyfin-sdk-typescript/pull/148)
+* API classes are no longer exposed via getters.
+  Instead you need to call a function passing the `Api` instance as a parameter. For example: `getSystemApi(api)`. While I do feel this is a slightly worse developer experience, it was a necessary change to support tree-shaking. [#149](https://github.com/thornbill/jellyfin-sdk-typescript/pull/149)
+
 ## Install
 
 ```sh
@@ -61,11 +74,11 @@ const api = jellyfin.createApi(best.address);
 // are available as api.systemApi.
 
 // Fetch the public system info
-const info = await api.systemApi.getPublicSystemInfo();
+const info = await getSystemApi(api).getPublicSystemInfo();
 console.log('Info =>', info.data);
 
 // Fetch the list of public users
-const users = await api.userApi.getPublicUsers();
+const users = await getUserApi(api).getPublicUsers();
 console.log('Users =>', users.data);
 
 // A helper method for authentication has been added to the SDK because
@@ -76,7 +89,7 @@ console.log('Auth =>', auth.data);
 
 // Authentication state is stored internally in the Api class, so now
 // requests that require authentication can be made normally
-const libraries = await api.libraryApi.getMediaFolders();
+const libraries = await getLibraryApi(api).getMediaFolders();
 console.log('Libraries =>', libraries.data);
 
 // A helper method for logging out the current user has been added to the

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -9,7 +9,7 @@ import { mocked } from 'ts-jest/utils';
 
 import { Api, AUTHORIZATION_HEADER } from '..';
 import { SERVER_URL, TEST_CLIENT, TEST_DEVICE } from '../__helpers__/common';
-import { ActivityLogApi, ApiKeyApi, ArtistsApi, AudioApi, BrandingApi, ChannelsApi, CollectionApi, ConfigurationApi, DashboardApi, DevicesApi, DisplayPreferencesApi, DlnaApi, DlnaServerApi, DynamicHlsApi, EnvironmentApi, FilterApi, GenresApi, HlsSegmentApi, ImageApi, ImageByNameApi, ImageType, InstantMixApi, ItemLookupApi, ItemRefreshApi, ItemsApi, ItemUpdateApi, LibraryApi, LibraryStructureApi, LiveTvApi, LocalizationApi, MediaInfoApi, MoviesApi, MusicGenresApi, NotificationsApi, PackageApi, PersonsApi, PlaylistsApi, PlaystateApi, PluginsApi, QuickConnectApi, RemoteImageApi, ScheduledTasksApi, SearchApi, SessionApi, StartupApi, StudiosApi, SubtitleApi, SuggestionsApi, SyncPlayApi, SystemApi, TimeSyncApi, TrailersApi, TvShowsApi, UniversalAudioApi, UserApi, UserLibraryApi, UserViewsApi, VideoAttachmentsApi, VideoHlsApi, VideosApi, YearsApi } from '../generated-client';
+import { ImageType } from '../generated-client/models';
 import { getAuthorizationHeader } from '../utils';
 
 jest.mock('axios', () => ({
@@ -78,70 +78,5 @@ describe('Api', () => {
 		expect(api.getItemImageUrl('TEST')).toBe('https://example.com/Items/TEST/Images/Primary');
 		expect(api.getItemImageUrl('TEST', ImageType.Backdrop, { fillWidth: 100, fillHeight: 100 }))
 			.toBe('https://example.com/Items/TEST/Images/Backdrop?fillWidth=100&fillHeight=100');
-	});
-
-	it('should return api instances', () => {
-		const api = new Api(SERVER_URL, TEST_CLIENT, TEST_DEVICE);
-
-		expect(api.activityLogApi).toBeInstanceOf(ActivityLogApi);
-		expect(api.apiKeyApi).toBeInstanceOf(ApiKeyApi);
-		expect(api.artistsApi).toBeInstanceOf(ArtistsApi);
-		expect(api.audioApi).toBeInstanceOf(AudioApi);
-		expect(api.brandingApi).toBeInstanceOf(BrandingApi);
-		expect(api.channelsApi).toBeInstanceOf(ChannelsApi);
-		expect(api.collectionApi).toBeInstanceOf(CollectionApi);
-		expect(api.configurationApi).toBeInstanceOf(ConfigurationApi);
-		expect(api.dashboardApi).toBeInstanceOf(DashboardApi);
-		expect(api.devicesApi).toBeInstanceOf(DevicesApi);
-		expect(api.displayPreferencesApi).toBeInstanceOf(DisplayPreferencesApi);
-		expect(api.dlnaApi).toBeInstanceOf(DlnaApi);
-		expect(api.dlnaServerApi).toBeInstanceOf(DlnaServerApi);
-		expect(api.dynamicHlsApi).toBeInstanceOf(DynamicHlsApi);
-		expect(api.environmentApi).toBeInstanceOf(EnvironmentApi);
-		expect(api.filterApi).toBeInstanceOf(FilterApi);
-		expect(api.genresApi).toBeInstanceOf(GenresApi);
-		expect(api.hlsSegmentApi).toBeInstanceOf(HlsSegmentApi);
-		expect(api.imageApi).toBeInstanceOf(ImageApi);
-		expect(api.imageByNameApi).toBeInstanceOf(ImageByNameApi);
-		expect(api.instantMixApi).toBeInstanceOf(InstantMixApi);
-		expect(api.itemLookupApi).toBeInstanceOf(ItemLookupApi);
-		expect(api.itemRefreshApi).toBeInstanceOf(ItemRefreshApi);
-		expect(api.itemUpdateApi).toBeInstanceOf(ItemUpdateApi);
-		expect(api.itemsApi).toBeInstanceOf(ItemsApi);
-		expect(api.libraryApi).toBeInstanceOf(LibraryApi);
-		expect(api.libraryStructureApi).toBeInstanceOf(LibraryStructureApi);
-		expect(api.liveTvApi).toBeInstanceOf(LiveTvApi);
-		expect(api.localizationApi).toBeInstanceOf(LocalizationApi);
-		expect(api.mediaInfoApi).toBeInstanceOf(MediaInfoApi);
-		expect(api.moviesApi).toBeInstanceOf(MoviesApi);
-		expect(api.musicGenresApi).toBeInstanceOf(MusicGenresApi);
-		expect(api.notificationsApi).toBeInstanceOf(NotificationsApi);
-		expect(api.packageApi).toBeInstanceOf(PackageApi);
-		expect(api.personsApi).toBeInstanceOf(PersonsApi);
-		expect(api.playlistsApi).toBeInstanceOf(PlaylistsApi);
-		expect(api.playstateApi).toBeInstanceOf(PlaystateApi);
-		expect(api.pluginsApi).toBeInstanceOf(PluginsApi);
-		expect(api.quickConnectApi).toBeInstanceOf(QuickConnectApi);
-		expect(api.remoteImageApi).toBeInstanceOf(RemoteImageApi);
-		expect(api.scheduledTasksApi).toBeInstanceOf(ScheduledTasksApi);
-		expect(api.searchApi).toBeInstanceOf(SearchApi);
-		expect(api.sessionApi).toBeInstanceOf(SessionApi);
-		expect(api.startupApi).toBeInstanceOf(StartupApi);
-		expect(api.studiosApi).toBeInstanceOf(StudiosApi);
-		expect(api.subtitleApi).toBeInstanceOf(SubtitleApi);
-		expect(api.suggestionsApi).toBeInstanceOf(SuggestionsApi);
-		expect(api.syncPlayApi).toBeInstanceOf(SyncPlayApi);
-		expect(api.systemApi).toBeInstanceOf(SystemApi);
-		expect(api.timeSyncApi).toBeInstanceOf(TimeSyncApi);
-		expect(api.trailersApi).toBeInstanceOf(TrailersApi);
-		expect(api.tvShowsApi).toBeInstanceOf(TvShowsApi);
-		expect(api.universalAudioApi).toBeInstanceOf(UniversalAudioApi);
-		expect(api.userApi).toBeInstanceOf(UserApi);
-		expect(api.userLibraryApi).toBeInstanceOf(UserLibraryApi);
-		expect(api.userViewsApi).toBeInstanceOf(UserViewsApi);
-		expect(api.videoAttachmentsApi).toBeInstanceOf(VideoAttachmentsApi);
-		expect(api.videoHlsApi).toBeInstanceOf(VideoHlsApi);
-		expect(api.videosApi).toBeInstanceOf(VideosApi);
-		expect(api.yearsApi).toBeInstanceOf(YearsApi);
 	});
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,10 +5,14 @@
  */
 import globalInstance, { AxiosInstance, AxiosResponse } from 'axios';
 
-import { ActivityLogApi, ApiKeyApi, ArtistsApi, AudioApi, AuthenticationResult, BrandingApi, ChannelsApi, CollectionApi, Configuration, ConfigurationApi, DashboardApi, DevicesApi, DisplayPreferencesApi, DlnaApi, DlnaServerApi, DynamicHlsApi, EnvironmentApi, FilterApi, GenresApi, HlsSegmentApi, ImageApi, ImageByNameApi, ImageType, InstantMixApi, ItemLookupApi, ItemRefreshApi, ItemsApi, ItemUpdateApi, LibraryApi, LibraryStructureApi, LiveTvApi, LocalizationApi, MediaInfoApi, MoviesApi, MusicGenresApi, NotificationsApi, PackageApi, PersonsApi, PlaylistsApi, PlaystateApi, PluginsApi, QuickConnectApi, RemoteImageApi, ScheduledTasksApi, SearchApi, SessionApi, StartupApi, StudiosApi, SubtitleApi, SuggestionsApi, SyncPlayApi, SystemApi, TimeSyncApi, TrailersApi, TvShowsApi, UniversalAudioApi, UserApi, UserLibraryApi, UserViewsApi, VideoAttachmentsApi, VideoHlsApi, VideosApi, YearsApi } from './generated-client';
+import { Configuration } from './generated-client/configuration';
+import { AuthenticationResult } from './generated-client/models/authentication-result';
+import { ImageType } from './generated-client/models/image-type';
 import { ClientInfo, DeviceInfo } from './models';
 import { ImageRequestParameters } from './models/api/image-request-parameters';
 import { getAuthorizationHeader } from './utils';
+import { getSessionApi } from './utils/api/session-api';
+import { getUserApi } from './utils/api/user-api';
 
 // HACK: Axios does not export types for axios/lib. This is a workaround.
 type BuildFullPathFunction = (baseURL?: string, requestedURL?: string) => string;
@@ -40,7 +44,7 @@ export class Api {
 		this.axiosInstance = axiosInstance;
 	}
 
-	private get configuration(): Configuration {
+	get configuration(): Configuration {
 		return new Configuration({
 			basePath: this.basePath,
 			apiKey: this.authorizationHeader
@@ -53,7 +57,7 @@ export class Api {
 	 * @param password The user password if required.
 	 */
 	authenticateUserByName(username: string, password?: string): Promise<AxiosResponse<AuthenticationResult>> {
-		return this.userApi.authenticateUserByName(
+		return getUserApi(this).authenticateUserByName(
 			// The axios client does some strange wrapping of the param object
 			{ authenticateUserByName: { Username: username, Pw: password } },
 			// The authorization header is required for the request to succeed
@@ -69,7 +73,7 @@ export class Api {
 	 * Convenience method for logging out and updating the internal state.
 	 */
 	logout(): Promise<AxiosResponse<never> | AxiosResponse<void>> {
-		return this.sessionApi.reportSessionEnded().then(response => {
+		return getSessionApi(this).reportSessionEnded().then(response => {
 			this.accessToken = '';
 			return response;
 		});
@@ -95,245 +99,5 @@ export class Api {
 
 	get authorizationHeader(): string {
 		return getAuthorizationHeader(this.clientInfo, this.deviceInfo, this.accessToken);
-	}
-
-	get activityLogApi(): ActivityLogApi {
-		return new ActivityLogApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get apiKeyApi(): ApiKeyApi {
-		return new ApiKeyApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get artistsApi(): ArtistsApi {
-		return new ArtistsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get audioApi(): AudioApi {
-		return new AudioApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get brandingApi(): BrandingApi {
-		return new BrandingApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get channelsApi(): ChannelsApi {
-		return new ChannelsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get collectionApi(): CollectionApi {
-		return new CollectionApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get configurationApi(): ConfigurationApi {
-		return new ConfigurationApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get dashboardApi(): DashboardApi {
-		return new DashboardApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get devicesApi(): DevicesApi {
-		return new DevicesApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get displayPreferencesApi(): DisplayPreferencesApi {
-		return new DisplayPreferencesApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get dlnaApi(): DlnaApi {
-		return new DlnaApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get dlnaServerApi(): DlnaServerApi {
-		return new DlnaServerApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get dynamicHlsApi(): DynamicHlsApi {
-		return new DynamicHlsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get environmentApi(): EnvironmentApi {
-		return new EnvironmentApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get filterApi(): FilterApi {
-		return new FilterApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get genresApi(): GenresApi {
-		return new GenresApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get hlsSegmentApi(): HlsSegmentApi {
-		return new HlsSegmentApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get imageApi(): ImageApi {
-		return new ImageApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get imageByNameApi(): ImageByNameApi {
-		return new ImageByNameApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get instantMixApi(): InstantMixApi {
-		return new InstantMixApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get itemLookupApi(): ItemLookupApi {
-		return new ItemLookupApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get itemRefreshApi(): ItemRefreshApi {
-		return new ItemRefreshApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get itemUpdateApi(): ItemUpdateApi {
-		return new ItemUpdateApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get itemsApi(): ItemsApi {
-		return new ItemsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get libraryApi(): LibraryApi {
-		return new LibraryApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get libraryStructureApi(): LibraryStructureApi {
-		return new LibraryStructureApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get liveTvApi(): LiveTvApi {
-		return new LiveTvApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get localizationApi(): LocalizationApi {
-		return new LocalizationApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get mediaInfoApi(): MediaInfoApi {
-		return new MediaInfoApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get moviesApi(): MoviesApi {
-		return new MoviesApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get musicGenresApi(): MusicGenresApi {
-		return new MusicGenresApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get notificationsApi(): NotificationsApi {
-		return new NotificationsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get packageApi(): PackageApi {
-		return new PackageApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get personsApi(): PersonsApi {
-		return new PersonsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get playlistsApi(): PlaylistsApi {
-		return new PlaylistsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get playstateApi(): PlaystateApi {
-		return new PlaystateApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get pluginsApi(): PluginsApi {
-		return new PluginsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get quickConnectApi(): QuickConnectApi {
-		return new QuickConnectApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get remoteImageApi(): RemoteImageApi {
-		return new RemoteImageApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get scheduledTasksApi(): ScheduledTasksApi {
-		return new ScheduledTasksApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get searchApi(): SearchApi {
-		return new SearchApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get sessionApi(): SessionApi {
-		return new SessionApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get startupApi(): StartupApi {
-		return new StartupApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get studiosApi(): StudiosApi {
-		return new StudiosApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get subtitleApi(): SubtitleApi {
-		return new SubtitleApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get suggestionsApi(): SuggestionsApi {
-		return new SuggestionsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get syncPlayApi(): SyncPlayApi {
-		return new SyncPlayApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get systemApi(): SystemApi {
-		return new SystemApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get timeSyncApi(): TimeSyncApi {
-		return new TimeSyncApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get trailersApi(): TrailersApi {
-		return new TrailersApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get tvShowsApi(): TvShowsApi {
-		return new TvShowsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get universalAudioApi(): UniversalAudioApi {
-		return new UniversalAudioApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get userApi(): UserApi {
-		return new UserApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get userLibraryApi(): UserLibraryApi {
-		return new UserLibraryApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get userViewsApi(): UserViewsApi {
-		return new UserViewsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get videoAttachmentsApi(): VideoAttachmentsApi {
-		return new VideoAttachmentsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get videoHlsApi(): VideoHlsApi {
-		return new VideoHlsApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get videosApi(): VideosApi {
-		return new VideosApi(this.configuration, undefined, this.axiosInstance);
-	}
-
-	get yearsApi(): YearsApi {
-		return new YearsApi(this.configuration, undefined, this.axiosInstance);
 	}
 }

--- a/src/discovery/recommended-server-discovery.ts
+++ b/src/discovery/recommended-server-discovery.ts
@@ -8,7 +8,8 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { compare } from 'compare-versions';
 
 import { API_VERSION, Jellyfin, MINIMUM_VERSION, ProductNameIssue, RecommendedServerInfo, RecommendedServerInfoScore, RecommendedServerIssue, SlowResponseIssue, SystemInfoIssue, VersionMissingIssue, VersionOutdatedIssue, VersionUnsupportedIssue } from '..';
-import { PublicSystemInfo } from '../generated-client';
+import { PublicSystemInfo } from '../generated-client/models/public-system-info';
+import { getSystemApi } from '../utils/api/system-api';
 
 /** The result of a SystemInfo request. */
 interface SystemInfoResult {
@@ -92,7 +93,7 @@ export class RecommendedServerDiscovery {
 		const api = this.jellyfin.createApi(address);
 		const startTime = Date.now();
 
-		return api.systemApi.getPublicSystemInfo({ timeout: HTTP_TIMEOUT })
+		return getSystemApi(api).getPublicSystemInfo({ timeout: HTTP_TIMEOUT })
 			.then(response => ({
 				address,
 				response,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-// TODO: Should the generated client be exported?
 export * as discovery from './discovery';
 export * as utils from './utils';
 

--- a/src/models/api/image-request-parameters.ts
+++ b/src/models/api/image-request-parameters.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ImageFormat } from '../../generated-client';
+import { ImageFormat } from '../../generated-client/models/image-format';
 
 /**
  * Interface representing supported request parameters for the getItemImage API.

--- a/src/models/recommended-server-info.ts
+++ b/src/models/recommended-server-info.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { PublicSystemInfo } from '../generated-client';
+import { PublicSystemInfo } from '../generated-client/models/public-system-info';
 
 import { RecommendedServerIssue } from './recommended-server-issue';
 

--- a/src/utils/api/__tests__/api.test.ts
+++ b/src/utils/api/__tests__/api.test.ts
@@ -1,0 +1,142 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { SERVER_URL, TEST_CLIENT, TEST_DEVICE } from '../../../__helpers__/common';
+
+import { Api } from '../../../api';
+import { ActivityLogApi, ApiKeyApi, ArtistsApi, AudioApi, BrandingApi, ChannelsApi, CollectionApi, ConfigurationApi, DashboardApi, DevicesApi, DisplayPreferencesApi, DlnaApi, DlnaServerApi, DynamicHlsApi, EnvironmentApi, FilterApi, GenresApi, HlsSegmentApi, ImageApi, ImageByNameApi, InstantMixApi, ItemLookupApi, ItemRefreshApi, ItemsApi, ItemUpdateApi, LibraryApi, LibraryStructureApi, LiveTvApi, LocalizationApi, MediaInfoApi, MoviesApi, MusicGenresApi, NotificationsApi, PackageApi, PersonsApi, PlaylistsApi, PlaystateApi, PluginsApi, QuickConnectApi, RemoteImageApi, ScheduledTasksApi, SearchApi, SessionApi, StartupApi, StudiosApi, SubtitleApi, SuggestionsApi, SyncPlayApi, SystemApi, TimeSyncApi, TrailersApi, TvShowsApi, UniversalAudioApi, UserApi, UserLibraryApi, UserViewsApi, VideoAttachmentsApi, VideoHlsApi, VideosApi, YearsApi } from '../../../generated-client/api';
+import { getActivityLogApi } from '../activity-log-api';
+import { getApiKeyApi } from '../api-key-api';
+import { getArtistsApi } from '../artists-api';
+import { getAudioApi } from '../audio-api';
+import { getBrandingApi } from '../branding-api';
+import { getChannelsApi } from '../channels-api';
+import { getCollectionApi } from '../collection-api';
+import { getConfigurationApi } from '../configuration-api';
+import { getDashboardApi } from '../dashboard-api';
+import { getDevicesApi } from '../devices-api';
+import { getDisplayPreferencesApi } from '../display-preferences-api';
+import { getDlnaApi } from '../dlna-api';
+import { getDlnaServerApi } from '../dlna-server-api';
+import { getDynamicHlsApi } from '../dynamic-hls-api';
+import { getEnvironmentApi } from '../environment-api';
+import { getFilterApi } from '../filter-api';
+import { getGenresApi } from '../genres-api';
+import { getHlsSegmentApi } from '../hls-segment-api';
+import { getImageApi } from '../image-api';
+import { getImageByNameApi } from '../image-by-name-api';
+import { getInstantMixApi } from '../instant-mix-api';
+import { getItemLookupApi } from '../item-lookup-api';
+import { getItemRefreshApi } from '../item-refresh-api';
+import { getItemUpdateApi } from '../item-update-api';
+import { getItemsApi } from '../items-api';
+import { getLibraryApi } from '../library-api';
+import { getLibraryStructureApi } from '../library-structure-api';
+import { getLiveTvApi } from '../live-tv-api';
+import { getLocalizationApi } from '../localization-api';
+import { getMediaInfoApi } from '../media-info-api';
+import { getMoviesApi } from '../movies-api';
+import { getMusicGenresApi } from '../music-genres-api';
+import { getNotificationsApi } from '../notifications-api';
+import { getPackageApi } from '../package-api';
+import { getPersonsApi } from '../persons-api';
+import { getPlaylistsApi } from '../playlists-api';
+import { getPlaystateApi } from '../playstate-api';
+import { getPluginsApi } from '../plugins-api';
+import { getQuickConnectApi } from '../quick-connect-api';
+import { getRemoteImageApi } from '../remote-image-api';
+import { getScheduledTasksApi } from '../scheduled-tasks-api';
+import { getSearchApi } from '../search-api';
+import { getSessionApi } from '../session-api';
+import { getStartupApi } from '../startup-api';
+import { getStudiosApi } from '../studios-api';
+import { getSubtitleApi } from '../subtitle-api';
+import { getSuggestionsApi } from '../suggestions-api';
+import { getSyncPlayApi } from '../sync-play-api';
+import { getSystemApi } from '../system-api';
+import { getTimeSyncApi } from '../time-sync-api';
+import { getTrailersApi } from '../trailers-api';
+import { getTvShowsApi } from '../tv-shows-api';
+import { getUniversalAudioApi } from '../universal-audio-api';
+import { getUserApi } from '../user-api';
+import { getUserLibraryApi } from '../user-library-api';
+import { getUserViewsApi } from '../user-views-api';
+import { getVideoAttachmentsApi } from '../video-attachments-api';
+import { getVideoHlsApi } from '../video-hls-api';
+import { getVideosApi } from '../videos-api';
+import { getYearsApi } from '../years-api';
+
+/**
+ * Api helper function tests.
+ *
+ * @group unit/utils/api
+ */
+describe('Api Utilities', () => {
+	it('get api functions should return api instances', () => {
+		const api = new Api(SERVER_URL, TEST_CLIENT, TEST_DEVICE);
+
+		expect(getActivityLogApi(api)).toBeInstanceOf(ActivityLogApi);
+		expect(getApiKeyApi(api)).toBeInstanceOf(ApiKeyApi);
+		expect(getArtistsApi(api)).toBeInstanceOf(ArtistsApi);
+		expect(getAudioApi(api)).toBeInstanceOf(AudioApi);
+		expect(getBrandingApi(api)).toBeInstanceOf(BrandingApi);
+		expect(getChannelsApi(api)).toBeInstanceOf(ChannelsApi);
+		expect(getCollectionApi(api)).toBeInstanceOf(CollectionApi);
+		expect(getConfigurationApi(api)).toBeInstanceOf(ConfigurationApi);
+		expect(getDashboardApi(api)).toBeInstanceOf(DashboardApi);
+		expect(getDevicesApi(api)).toBeInstanceOf(DevicesApi);
+		expect(getDisplayPreferencesApi(api)).toBeInstanceOf(DisplayPreferencesApi);
+		expect(getDlnaApi(api)).toBeInstanceOf(DlnaApi);
+		expect(getDlnaServerApi(api)).toBeInstanceOf(DlnaServerApi);
+		expect(getDynamicHlsApi(api)).toBeInstanceOf(DynamicHlsApi);
+		expect(getEnvironmentApi(api)).toBeInstanceOf(EnvironmentApi);
+		expect(getFilterApi(api)).toBeInstanceOf(FilterApi);
+		expect(getGenresApi(api)).toBeInstanceOf(GenresApi);
+		expect(getHlsSegmentApi(api)).toBeInstanceOf(HlsSegmentApi);
+		expect(getImageApi(api)).toBeInstanceOf(ImageApi);
+		expect(getImageByNameApi(api)).toBeInstanceOf(ImageByNameApi);
+		expect(getInstantMixApi(api)).toBeInstanceOf(InstantMixApi);
+		expect(getItemLookupApi(api)).toBeInstanceOf(ItemLookupApi);
+		expect(getItemRefreshApi(api)).toBeInstanceOf(ItemRefreshApi);
+		expect(getItemUpdateApi(api)).toBeInstanceOf(ItemUpdateApi);
+		expect(getItemsApi(api)).toBeInstanceOf(ItemsApi);
+		expect(getLibraryApi(api)).toBeInstanceOf(LibraryApi);
+		expect(getLibraryStructureApi(api)).toBeInstanceOf(LibraryStructureApi);
+		expect(getLiveTvApi(api)).toBeInstanceOf(LiveTvApi);
+		expect(getLocalizationApi(api)).toBeInstanceOf(LocalizationApi);
+		expect(getMediaInfoApi(api)).toBeInstanceOf(MediaInfoApi);
+		expect(getMoviesApi(api)).toBeInstanceOf(MoviesApi);
+		expect(getMusicGenresApi(api)).toBeInstanceOf(MusicGenresApi);
+		expect(getNotificationsApi(api)).toBeInstanceOf(NotificationsApi);
+		expect(getPackageApi(api)).toBeInstanceOf(PackageApi);
+		expect(getPersonsApi(api)).toBeInstanceOf(PersonsApi);
+		expect(getPlaylistsApi(api)).toBeInstanceOf(PlaylistsApi);
+		expect(getPlaystateApi(api)).toBeInstanceOf(PlaystateApi);
+		expect(getPluginsApi(api)).toBeInstanceOf(PluginsApi);
+		expect(getQuickConnectApi(api)).toBeInstanceOf(QuickConnectApi);
+		expect(getRemoteImageApi(api)).toBeInstanceOf(RemoteImageApi);
+		expect(getScheduledTasksApi(api)).toBeInstanceOf(ScheduledTasksApi);
+		expect(getSearchApi(api)).toBeInstanceOf(SearchApi);
+		expect(getSessionApi(api)).toBeInstanceOf(SessionApi);
+		expect(getStartupApi(api)).toBeInstanceOf(StartupApi);
+		expect(getStudiosApi(api)).toBeInstanceOf(StudiosApi);
+		expect(getSubtitleApi(api)).toBeInstanceOf(SubtitleApi);
+		expect(getSuggestionsApi(api)).toBeInstanceOf(SuggestionsApi);
+		expect(getSyncPlayApi(api)).toBeInstanceOf(SyncPlayApi);
+		expect(getSystemApi(api)).toBeInstanceOf(SystemApi);
+		expect(getTimeSyncApi(api)).toBeInstanceOf(TimeSyncApi);
+		expect(getTrailersApi(api)).toBeInstanceOf(TrailersApi);
+		expect(getTvShowsApi(api)).toBeInstanceOf(TvShowsApi);
+		expect(getUniversalAudioApi(api)).toBeInstanceOf(UniversalAudioApi);
+		expect(getUserApi(api)).toBeInstanceOf(UserApi);
+		expect(getUserLibraryApi(api)).toBeInstanceOf(UserLibraryApi);
+		expect(getUserViewsApi(api)).toBeInstanceOf(UserViewsApi);
+		expect(getVideoAttachmentsApi(api)).toBeInstanceOf(VideoAttachmentsApi);
+		expect(getVideoHlsApi(api)).toBeInstanceOf(VideoHlsApi);
+		expect(getVideosApi(api)).toBeInstanceOf(VideosApi);
+		expect(getYearsApi(api)).toBeInstanceOf(YearsApi);
+	});
+});

--- a/src/utils/api/activity-log-api.ts
+++ b/src/utils/api/activity-log-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ActivityLogApi } from '../../generated-client/api/activity-log-api';
+
+export function getActivityLogApi(api: Api): ActivityLogApi {
+	return new ActivityLogApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/api-key-api.ts
+++ b/src/utils/api/api-key-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ApiKeyApi } from '../../generated-client/api/api-key-api';
+
+export function getApiKeyApi(api: Api): ApiKeyApi {
+	return new ApiKeyApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/artists-api.ts
+++ b/src/utils/api/artists-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ArtistsApi } from '../../generated-client/api/artists-api';
+
+export function getArtistsApi(api: Api): ArtistsApi {
+	return new ArtistsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/audio-api.ts
+++ b/src/utils/api/audio-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { AudioApi } from '../../generated-client/api/audio-api';
+
+export function getAudioApi(api: Api): AudioApi {
+	return new AudioApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/branding-api.ts
+++ b/src/utils/api/branding-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { BrandingApi } from '../../generated-client/api/branding-api';
+
+export function getBrandingApi(api: Api): BrandingApi {
+	return new BrandingApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/channels-api.ts
+++ b/src/utils/api/channels-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ChannelsApi } from '../../generated-client/api/channels-api';
+
+export function getChannelsApi(api: Api): ChannelsApi {
+	return new ChannelsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/collection-api.ts
+++ b/src/utils/api/collection-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { CollectionApi } from '../../generated-client/api/collection-api';
+
+export function getCollectionApi(api: Api): CollectionApi {
+	return new CollectionApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/configuration-api.ts
+++ b/src/utils/api/configuration-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ConfigurationApi } from '../../generated-client/api/configuration-api';
+
+export function getConfigurationApi(api: Api): ConfigurationApi {
+	return new ConfigurationApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/dashboard-api.ts
+++ b/src/utils/api/dashboard-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DashboardApi } from '../../generated-client/api/dashboard-api';
+
+export function getDashboardApi(api: Api): DashboardApi {
+	return new DashboardApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/devices-api.ts
+++ b/src/utils/api/devices-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DevicesApi } from '../../generated-client/api/devices-api';
+
+export function getDevicesApi(api: Api): DevicesApi {
+	return new DevicesApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/display-preferences-api.ts
+++ b/src/utils/api/display-preferences-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DisplayPreferencesApi } from '../../generated-client/api/display-preferences-api';
+
+export function getDisplayPreferencesApi(api: Api): DisplayPreferencesApi {
+	return new DisplayPreferencesApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/dlna-api.ts
+++ b/src/utils/api/dlna-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DlnaApi } from '../../generated-client/api/dlna-api';
+
+export function getDlnaApi(api: Api): DlnaApi {
+	return new DlnaApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/dlna-server-api.ts
+++ b/src/utils/api/dlna-server-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DlnaServerApi } from '../../generated-client/api/dlna-server-api';
+
+export function getDlnaServerApi(api: Api): DlnaServerApi {
+	return new DlnaServerApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/dynamic-hls-api.ts
+++ b/src/utils/api/dynamic-hls-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { DynamicHlsApi } from '../../generated-client/api/dynamic-hls-api';
+
+export function getDynamicHlsApi(api: Api): DynamicHlsApi {
+	return new DynamicHlsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/environment-api.ts
+++ b/src/utils/api/environment-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { EnvironmentApi } from '../../generated-client/api/environment-api';
+
+export function getEnvironmentApi(api: Api): EnvironmentApi {
+	return new EnvironmentApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/filter-api.ts
+++ b/src/utils/api/filter-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { FilterApi } from '../../generated-client/api/filter-api';
+
+export function getFilterApi(api: Api): FilterApi {
+	return new FilterApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/genres-api.ts
+++ b/src/utils/api/genres-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { GenresApi } from '../../generated-client/api/genres-api';
+
+export function getGenresApi(api: Api): GenresApi {
+	return new GenresApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/hls-segment-api.ts
+++ b/src/utils/api/hls-segment-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { HlsSegmentApi } from '../../generated-client/api/hls-segment-api';
+
+export function getHlsSegmentApi(api: Api): HlsSegmentApi {
+	return new HlsSegmentApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/image-api.ts
+++ b/src/utils/api/image-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ImageApi } from '../../generated-client/api/image-api';
+
+export function getImageApi(api: Api): ImageApi {
+	return new ImageApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/image-by-name-api.ts
+++ b/src/utils/api/image-by-name-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ImageByNameApi } from '../../generated-client/api/image-by-name-api';
+
+export function getImageByNameApi(api: Api): ImageByNameApi {
+	return new ImageByNameApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/instant-mix-api.ts
+++ b/src/utils/api/instant-mix-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { InstantMixApi } from '../../generated-client/api/instant-mix-api';
+
+export function getInstantMixApi(api: Api): InstantMixApi {
+	return new InstantMixApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/item-lookup-api.ts
+++ b/src/utils/api/item-lookup-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ItemLookupApi } from '../../generated-client/api/item-lookup-api';
+
+export function getItemLookupApi(api: Api): ItemLookupApi {
+	return new ItemLookupApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/item-refresh-api.ts
+++ b/src/utils/api/item-refresh-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ItemRefreshApi } from '../../generated-client/api/item-refresh-api';
+
+export function getItemRefreshApi(api: Api): ItemRefreshApi {
+	return new ItemRefreshApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/item-update-api.ts
+++ b/src/utils/api/item-update-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ItemUpdateApi } from '../../generated-client/api/item-update-api';
+
+export function getItemUpdateApi(api: Api): ItemUpdateApi {
+	return new ItemUpdateApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/items-api.ts
+++ b/src/utils/api/items-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ItemsApi } from '../../generated-client/api/items-api';
+
+export function getItemsApi(api: Api): ItemsApi {
+	return new ItemsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/library-api.ts
+++ b/src/utils/api/library-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { LibraryApi } from '../../generated-client/api/library-api';
+
+export function getLibraryApi(api: Api): LibraryApi {
+	return new LibraryApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/library-structure-api.ts
+++ b/src/utils/api/library-structure-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { LibraryStructureApi } from '../../generated-client/api/library-structure-api';
+
+export function getLibraryStructureApi(api: Api): LibraryStructureApi {
+	return new LibraryStructureApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/live-tv-api.ts
+++ b/src/utils/api/live-tv-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { LiveTvApi } from '../../generated-client/api/live-tv-api';
+
+export function getLiveTvApi(api: Api): LiveTvApi {
+	return new LiveTvApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/localization-api.ts
+++ b/src/utils/api/localization-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { LocalizationApi } from '../../generated-client/api/localization-api';
+
+export function getLocalizationApi(api: Api): LocalizationApi {
+	return new LocalizationApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/media-info-api.ts
+++ b/src/utils/api/media-info-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { MediaInfoApi } from '../../generated-client/api/media-info-api';
+
+export function getMediaInfoApi(api: Api): MediaInfoApi {
+	return new MediaInfoApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/movies-api.ts
+++ b/src/utils/api/movies-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { MoviesApi } from '../../generated-client/api/movies-api';
+
+export function getMoviesApi(api: Api): MoviesApi {
+	return new MoviesApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/music-genres-api.ts
+++ b/src/utils/api/music-genres-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { MusicGenresApi } from '../../generated-client/api/music-genres-api';
+
+export function getMusicGenresApi(api: Api): MusicGenresApi {
+	return new MusicGenresApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/notifications-api.ts
+++ b/src/utils/api/notifications-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { NotificationsApi } from '../../generated-client/api/notifications-api';
+
+export function getNotificationsApi(api: Api): NotificationsApi {
+	return new NotificationsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/package-api.ts
+++ b/src/utils/api/package-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { PackageApi } from '../../generated-client/api/package-api';
+
+export function getPackageApi(api: Api): PackageApi {
+	return new PackageApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/persons-api.ts
+++ b/src/utils/api/persons-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { PersonsApi } from '../../generated-client/api/persons-api';
+
+export function getPersonsApi(api: Api): PersonsApi {
+	return new PersonsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/playlists-api.ts
+++ b/src/utils/api/playlists-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { PlaylistsApi } from '../../generated-client/api/playlists-api';
+
+export function getPlaylistsApi(api: Api): PlaylistsApi {
+	return new PlaylistsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/playstate-api.ts
+++ b/src/utils/api/playstate-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { PlaystateApi } from '../../generated-client/api/playstate-api';
+
+export function getPlaystateApi(api: Api): PlaystateApi {
+	return new PlaystateApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/plugins-api.ts
+++ b/src/utils/api/plugins-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { PluginsApi } from '../../generated-client/api/plugins-api';
+
+export function getPluginsApi(api: Api): PluginsApi {
+	return new PluginsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/quick-connect-api.ts
+++ b/src/utils/api/quick-connect-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { QuickConnectApi } from '../../generated-client/api/quick-connect-api';
+
+export function getQuickConnectApi(api: Api): QuickConnectApi {
+	return new QuickConnectApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/remote-image-api.ts
+++ b/src/utils/api/remote-image-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { RemoteImageApi } from '../../generated-client/api/remote-image-api';
+
+export function getRemoteImageApi(api: Api): RemoteImageApi {
+	return new RemoteImageApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/scheduled-tasks-api.ts
+++ b/src/utils/api/scheduled-tasks-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { ScheduledTasksApi } from '../../generated-client/api/scheduled-tasks-api';
+
+export function getScheduledTasksApi(api: Api): ScheduledTasksApi {
+	return new ScheduledTasksApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/search-api.ts
+++ b/src/utils/api/search-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SearchApi } from '../../generated-client/api/search-api';
+
+export function getSearchApi(api: Api): SearchApi {
+	return new SearchApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/session-api.ts
+++ b/src/utils/api/session-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SessionApi } from '../../generated-client/api/session-api';
+
+export function getSessionApi(api: Api): SessionApi {
+	return new SessionApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/startup-api.ts
+++ b/src/utils/api/startup-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { StartupApi } from '../../generated-client/api/startup-api';
+
+export function getStartupApi(api: Api): StartupApi {
+	return new StartupApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/studios-api.ts
+++ b/src/utils/api/studios-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { StudiosApi } from '../../generated-client/api/studios-api';
+
+export function getStudiosApi(api: Api): StudiosApi {
+	return new StudiosApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/subtitle-api.ts
+++ b/src/utils/api/subtitle-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SubtitleApi } from '../../generated-client/api/subtitle-api';
+
+export function getSubtitleApi(api: Api): SubtitleApi {
+	return new SubtitleApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/suggestions-api.ts
+++ b/src/utils/api/suggestions-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SuggestionsApi } from '../../generated-client/api/suggestions-api';
+
+export function getSuggestionsApi(api: Api): SuggestionsApi {
+	return new SuggestionsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/sync-play-api.ts
+++ b/src/utils/api/sync-play-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SyncPlayApi } from '../../generated-client/api/sync-play-api';
+
+export function getSyncPlayApi(api: Api): SyncPlayApi {
+	return new SyncPlayApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/system-api.ts
+++ b/src/utils/api/system-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { SystemApi } from '../../generated-client/api/system-api';
+
+export function getSystemApi(api: Api): SystemApi {
+	return new SystemApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/time-sync-api.ts
+++ b/src/utils/api/time-sync-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { TimeSyncApi } from '../../generated-client/api/time-sync-api';
+
+export function getTimeSyncApi(api: Api): TimeSyncApi {
+	return new TimeSyncApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/trailers-api.ts
+++ b/src/utils/api/trailers-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { TrailersApi } from '../../generated-client/api/trailers-api';
+
+export function getTrailersApi(api: Api): TrailersApi {
+	return new TrailersApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/tv-shows-api.ts
+++ b/src/utils/api/tv-shows-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { TvShowsApi } from '../../generated-client/api/tv-shows-api';
+
+export function getTvShowsApi(api: Api): TvShowsApi {
+	return new TvShowsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/universal-audio-api.ts
+++ b/src/utils/api/universal-audio-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { UniversalAudioApi } from '../../generated-client/api/universal-audio-api';
+
+export function getUniversalAudioApi(api: Api): UniversalAudioApi {
+	return new UniversalAudioApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/user-api.ts
+++ b/src/utils/api/user-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { UserApi } from '../../generated-client/api/user-api';
+
+export function getUserApi(api: Api): UserApi {
+	return new UserApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/user-library-api.ts
+++ b/src/utils/api/user-library-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { UserLibraryApi } from '../../generated-client/api/user-library-api';
+
+export function getUserLibraryApi(api: Api): UserLibraryApi {
+	return new UserLibraryApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/user-views-api.ts
+++ b/src/utils/api/user-views-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { UserViewsApi } from '../../generated-client/api/user-views-api';
+
+export function getUserViewsApi(api: Api): UserViewsApi {
+	return new UserViewsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/video-attachments-api.ts
+++ b/src/utils/api/video-attachments-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { VideoAttachmentsApi } from '../../generated-client/api/video-attachments-api';
+
+export function getVideoAttachmentsApi(api: Api): VideoAttachmentsApi {
+	return new VideoAttachmentsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/video-hls-api.ts
+++ b/src/utils/api/video-hls-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { VideoHlsApi } from '../../generated-client/api/video-hls-api';
+
+export function getVideoHlsApi(api: Api): VideoHlsApi {
+	return new VideoHlsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/videos-api.ts
+++ b/src/utils/api/videos-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { VideosApi } from '../../generated-client/api/videos-api';
+
+export function getVideosApi(api: Api): VideosApi {
+	return new VideosApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/api/years-api.ts
+++ b/src/utils/api/years-api.ts
@@ -1,0 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Api } from '../../api';
+import { YearsApi } from '../../generated-client/api/years-api';
+
+export function getYearsApi(api: Api): YearsApi {
+	return new YearsApi(api.configuration, undefined, api.axiosInstance);
+}

--- a/src/utils/browser-profiles.ts
+++ b/src/utils/browser-profiles.ts
@@ -4,7 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { DeviceProfile, SubtitleDeliveryMethod, SubtitleProfile } from '../generated-client';
+import { DeviceProfile } from '../generated-client/models/device-profile';
+import { SubtitleDeliveryMethod } from '../generated-client/models/subtitle-delivery-method';
+import { SubtitleProfile } from '../generated-client/models/subtitle-profile';
 
 /**
  * Options parameters to build profiles


### PR DESCRIPTION
* Refactor getters for API classes to individual utility functions to allow for tree shaking.
* Add list of breaking changes in next release.

Fixes #137