### PR TITLE
Add test for ItemSortBy enum

### DIFF
--- a/src/models/api/__tests__/index.test.ts
+++ b/src/models/api/__tests__/index.test.ts
@@ -1,0 +1,20 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ItemSortBy } from '../index';
+
+/**
+ * Api model tests.
+ * NOTE: This is a really dumb case where because of the way TypeScript enums are generated in JavaScript we need to
+ * interact with the enum in a test (either directly or indirectly) for the file to be considered covered.
+ *
+ * @group unit/models/api
+ */
+describe('ItemSortBy', () => {
+	it('should exist', () => {
+		expect(ItemSortBy).toBeDefined();
+	});
+});


### PR DESCRIPTION
Adds a test for the `ItemSortBy` enum to fix it being reported as uncovered despite being a constant