### PR TITLE
Add workflow to update openapi spec and generated code

### DIFF
--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -20,17 +20,16 @@ jobs:
           check-latest: true
           cache: npm
 
-      - name: Set STABLE_API_VERSION
-        run: |
-          VERSION=$(curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json | jq -r .info.version)
-          echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
+      - name: Install Node.js dependencies
+        run: npm ci --no-audit
 
       - name: Update generated sources and create pull request
         uses: technote-space/create-pr-action@95c1e76dc9b65848afe397ea156666021f2e8243 # tag=v2
         with:
           EXECUTE_COMMANDS: |
-            npm ci --no-audit
             curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json -o openapi.json
+            VERSION=$(jq -r .info.version openapi.json)
+            echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
             npm run fix-schema
             npm run build:generated-client
           COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -28,16 +28,15 @@ jobs:
         with:
           EXECUTE_COMMANDS: |
             curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json -o openapi.json
-            VERSION=$(jq -r .info.version openapi.json)
-            echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
+            STABLE_API_VERSION=$(jq -r .info.version openapi.json)
             npm run fix-schema
             npm run build:generated-client
-          COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
+          COMMIT_MESSAGE: 'Update generated sources to ${{ STABLE_API_VERSION }}'
           COMMIT_NAME: 'jellyfin-bot'
           COMMIT_EMAIL: 'team@jellyfin.org'
           PR_BRANCH_PREFIX: 'openapi-update-'
           PR_BRANCH_NAME: '${PR_ID}'
-          PR_TITLE: 'Update OpenAPI to ${{ env.STABLE_API_VERSION }}'
+          PR_TITLE: 'Update OpenAPI to ${{ STABLE_API_VERSION }}'
           PR_BODY: |
             ## Changed files
 

--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -1,0 +1,51 @@
+name: SDK Update API from Spec
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  api-spec-update:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'jellyfin/jellyfin-sdk-typescript' }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          check-latest: true
+          cache: npm
+
+      - name: Set STABLE_API_VERSION
+        run: |
+          VERSION=$(curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json | jq -r .info.version)
+          echo "STABLE_API_VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Update generated sources and create pull request
+        uses: technote-space/create-pr-action@95c1e76dc9b65848afe397ea156666021f2e8243 # tag=v2
+        with:
+          EXECUTE_COMMANDS: |
+            npm ci --no-audit
+            curl -sL https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json -o openapi.json
+            npm run fix-schema
+            npm run build:generated-client
+          COMMIT_MESSAGE: 'Update generated sources to ${{ env.STABLE_API_VERSION }}'
+          COMMIT_NAME: 'jellyfin-bot'
+          COMMIT_EMAIL: 'team@jellyfin.org'
+          PR_BRANCH_PREFIX: 'openapi-update-'
+          PR_BRANCH_NAME: '${PR_ID}'
+          PR_TITLE: 'Update OpenAPI to ${{ env.STABLE_API_VERSION }}'
+          PR_BODY: |
+            ## Changed files
+
+            <details>
+              <summary>${FILES_SUMMARY}</summary>
+
+              ${FILES}
+
+            </details>
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
Add workflow to update the openapi spec to the latest stable release, update the generated client, and open a PR with the resulting changes.

Based on: https://github.com/jellyfin/jellyfin-sdk-kotlin/blob/master/.github/workflows/sdk-update-api-spec.yaml