### PR TITLE
Revert "Bump technote-space/create-pr-action from 2.1.1 to 2.1.2.2872065520"

### DIFF
--- a/.github/workflows/sdk-update-api-spec.yaml
+++ b/.github/workflows/sdk-update-api-spec.yaml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci --no-audit
 
       - name: Update generated sources and create pull request
-        uses: technote-space/create-pr-action@50d404fece196bf472c09b0cd6fddfec08ffa426 # tag=v2
+        uses: technote-space/create-pr-action@95c1e76dc9b65848afe397ea156666021f2e8243 # tag=v2
         with:
           EXECUTE_COMMANDS: |
             npm run build:generated-client


### PR DESCRIPTION
This update appears to be broken: https://github.com/jellyfin/jellyfin-sdk-typescript/runs/7959652454?check_suite_focus=true

Reverts jellyfin/jellyfin-sdk-typescript#233