### PR TITLE
Rename package to @jellyfin/sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br/>
 <a href="https://github.com/jellyfin/jellyfin-sdk-typescript/blob/master/LICENSE"><img alt="MPL-2.0 license" src="https://img.shields.io/github/license/jellyfin/jellyfin-sdk-typescript"></a>
 <a href="https://github.com/jellyfin/jellyfin-sdk-typescript/releases"><img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-sdk-typescript.svg"/></a>
-<a href="https://www.npmjs.com/package/@thornbill/jellyfin-sdk"><img alt="npm" src="https://img.shields.io/npm/v/@thornbill/jellyfin-sdk"></a>
+<a href="https://www.npmjs.com/package/@jellyfin/sdk"><img alt="npm" src="https://img.shields.io/npm/v/@jellyfin/sdk"></a>
 <a href="https://codecov.io/gh/jellyfin/jellyfin-sdk-typescript">
 <img alt="Codecov" src="https://img.shields.io/codecov/c/github/jellyfin/jellyfin-sdk-typescript?token=eFF0jvWiyq">
 </a>
@@ -22,13 +22,13 @@ A TypeScript SDK for Jellyfin.
 ## Install
 
 ```sh
-npm i --save @thornbill/jellyfin-sdk
+npm i --save @jellyfin/sdk
 ```
 
 or
 
 ```sh
-yarn add @thornbill/jellyfin-sdk
+yarn add @jellyfin/sdk
 ```
 
 ### Supported Jellyfin Versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@thornbill/jellyfin-sdk",
+  "name": "@jellyfin/sdk",
   "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@thornbill/jellyfin-sdk",
+      "name": "@jellyfin/sdk",
       "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@thornbill/jellyfin-sdk",
+  "name": "@jellyfin/sdk",
   "version": "0.6.0",
   "description": "A TypeScript SDK for Jellyfin.",
   "keywords": [


### PR DESCRIPTION
Renames the npm package to `@jellyfin/sdk`