### PR TITLE
Add api models to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage
 dist
+docs
 lib
 node_modules

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
   "typedocOptions": {
     "entryPoints": [
       "./src/index.ts",
-      "./src/generated-client/index.ts"
+      "./src/generated-client/index.ts",
+      "./src/models/api/index.ts"
     ],
     "out": "docs"
   },


### PR DESCRIPTION
The manually added API models were missing from the docs. This fixes that. :slightly_smiling_face: 