### PR TITLE
Target ES6 properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ await api.logout();
 
 ## Breaking Changes
 
+### v0.8.0
+
+* The library is now fully targeted to ES6/ES2015.
+  [#341](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/341)
+* Axios received a major version upgrade.
+  [#300](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/300)
+
 ### v0.7.0
 
 * Renamed package to @jellyfin/sdk.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "target": "ES6",
-    "module": "ES6",
+    "target": "ES2015",
+    "module": "ES2015",
     "moduleResolution": "Node",
     "declaration": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES6",
+    "module": "ES6",
+    "moduleResolution": "Node",
     "declaration": true,
     "noImplicitAny": true,
     "outDir": "lib"


### PR DESCRIPTION
See my previous fix at generator: https://github.com/OpenAPITools/openapi-generator/pull/10308

See https://www.typescriptlang.org/tsconfig#target and https://www.typescriptlang.org/tsconfig#module

```
Default:
CommonJS if target is ES3 or ES5,,ES6/ES2015 otherwise.
```

There's no tree shaking right now