### PR TITLE
Add GH action for publishing unstable builds

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -1,4 +1,4 @@
-name: SDK / Unstable branch
+name: SDK Unstable Branch
 
 on:
   schedule:

--- a/.github/workflows/sdk-unstable-publish.yaml
+++ b/.github/workflows/sdk-unstable-publish.yaml
@@ -1,0 +1,39 @@
+name: SDK Unstable Publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - openapi-unstable
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'jellyfin/jellyfin-sdk-typescript' }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        with:
+          ref: openapi-unstable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # tag=v3
+        with:
+          node-version: 16
+          check-latest: true
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Update package version
+        run: |
+          VERSION="0.0.0-unstable.$(date +%Y%m%d%H%M)+commit.$(git rev-parse HEAD)" && \
+          PACKAGE="$(jq --arg v "$VERSION" '.version = $v' package.json)" && \
+          echo -E "${PACKAGE}" > package.json
+
+      - name: Install Node.js dependencies
+        run: npm ci --no-audit
+
+      - name: Publish the SDK to npm
+        run: npm publish --tag unstable
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a GH action to publish unstable builds to npm when the `openapi-unstable` branch is committed to.

* Uses `0.0.0-unstable.$DATETIME` for the version number with the commit hash included as build metadata
* Uses the `unstable` tag for publishing that can be used instead of a version identifier in a `package.json` file