### PR TITLE
Disable npm version creating a git tag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 access=public
 lockfile-version=3
+git-tag-version=false
 save-exact=true


### PR DESCRIPTION
The tag is created when we create a release on GitHub, so having it created locally when `npm version` is used to increment the version is a bit annoying.