### PR TITLE
Fix lib/node_modules missing in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ __tests__
 coverage
 docs
 node_modules
+!/lib/node_modules
 scripts
 src
 


### PR DESCRIPTION
The v0.8.0 package on npm is broken due to the `lib/node_modules` directory being missing