### PR TITLE
Move sonar reporting to GH action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Run jest
         run: npx jest --coverage --group=unit
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-
       - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@c25d2e7e3def96d0d1781000d3c429da22cd6252 # v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -71,10 +71,12 @@ jobs:
         run: npx jest --coverage --group=unit
 
       - name: SonarCloud scan
+        if: ${{ github.repository == 'jellyfin/jellyfin-sdk-typescript' }}
         uses: SonarSource/sonarcloud-github-action@c25d2e7e3def96d0d1781000d3c429da22cd6252 # v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Upload coverage
+        if: ${{ github.repository == 'jellyfin/jellyfin-sdk-typescript' }}
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -72,3 +72,9 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+
+      - name: SonarCloud scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -21,5 +21,6 @@ openapi-templates
 codecov.yml
 jest.config.cjs
 rollup.config.js
+sonar-project.properties
 .sonarcloud.properties
 tsconfig.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,3 @@ sonar.exclusions = src/**/__tests__/**/*,src/**/__helpers__/**/*,src/generated-c
 # Paths for tests
 sonar.tests = src/
 sonar.test.inclusions = src/**/__tests__/**/*
-
-# Coverage report paths
-sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,6 @@
+sonar.projectKey=jellyfin_jellyfin-sdk-typescript
+sonar.organization=jellyfin
+
 # Paths for sources
 sonar.sources = src/
 sonar.exclusions = src/**/__tests__/**/*,src/**/__helpers__/**/*,src/generated-client/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,3 +8,6 @@ sonar.exclusions = src/**/__tests__/**/*,src/**/__helpers__/**/*,src/generated-c
 # Paths for tests
 sonar.tests = src/
 sonar.test.inclusions = src/**/__tests__/**/*
+
+# Coverage report paths
+sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,4 +10,4 @@ sonar.tests = src/
 sonar.test.inclusions = src/**/__tests__/**/*
 
 # Coverage report paths
-sonar.javascript.lcov.reportPaths = coverage/
+sonar.javascript.lcov.reportPaths = coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,6 @@ sonar.exclusions = src/**/__tests__/**/*,src/**/__helpers__/**/*,src/generated-c
 # Paths for tests
 sonar.tests = src/
 sonar.test.inclusions = src/**/__tests__/**/*
+
+# Coverage report paths
+sonar.javascript.lcov.reportPaths = coverage/


### PR DESCRIPTION
Updates to using GH Actions to run the SonarCloud scans. This allows us to configure code coverage reporting so we can (hopefully) remove codecov and reduce some noise on PRs.

Screenshot of test coverage on sonar's summary for the PR:
![Screenshot 2023-10-11 at 15-30-41 jellyfin-sdk-typescript - Jellyfin](https://github.com/jellyfin/jellyfin-sdk-typescript/assets/3450688/1559f786-3517-4653-9ec2-2fdcdf428937)
