### PR TITLE
Enable peer dependencies in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>jellyfin/.github//renovate-presets/nodejs",
-    ":semanticCommitsDisabled"
+    "github>jellyfin/.github//renovate-presets/nodejs"
+  ],
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchDepTypes": [
+        "peerDependencies"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
* Enable peer dependency updates by renovate
* Remove disabling semantic commits since they are no longer enabled in the org config