### PR TITLE
Fix missing lcov test reporter

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 		environment: 'node',
 		coverage: {
 			include: ['src'],
-			exclude: ['**/__helpers__/**', '**/generated-client/**']
+			exclude: ['**/__helpers__/**', '**/generated-client/**'],
+			reporter: [ 'text', 'html', 'lcov', 'json' ]
 		}
 	}
 });


### PR DESCRIPTION
Sonar bases its test coverage on the lcov report. Vitest does not generate that report by default so we need to explicitly add it as a reporter.