### PR TITLE
Update build target to es2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2018",
     "module": "ES2015",
     "moduleResolution": "Node",
     "declaration": true,


### PR DESCRIPTION
Updates the build target to es2018 which removes the tslib polyfills. If the sdk is being used somewhere that doesn't support es2018 features it will need built with something like babel to support older versions (this is already done in jellyfin-web).

Fixes #487 