### PR TITLE
Specify origin for unstable workflow rebase

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Update unstable branch from master
-        run: git rebase master
+        run: git rebase origin/master
 
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
Should fix the failure in https://github.com/jellyfin/jellyfin-sdk-typescript/actions/runs/9747650259/job/26900844522 by specifying the origin explicitly.