### PR TITLE
Fix checkout depth in unstable workflow

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: openapi-unstable
+          fetch-depth: 0
           token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Update unstable branch from master


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-sdk-typescript/pull/728 did not fix the underlying issue because the `master` branch was not included in the clone by the checkout action by default :upside_down_face: 