### PR TITLE
Configure the git user before rebasing

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -24,7 +24,10 @@ jobs:
           token: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Update unstable branch from master
-        run: git rebase origin/master
+        run: |
+          git config user.name jellyfin-bot
+          git config user.email team@jellyfin.org
+          git rebase origin/master
 
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -57,8 +60,6 @@ jobs:
         continue-on-error: true
         run: |
           ! git diff --exit-code --no-patch
-          git config user.name jellyfin-bot
-          git config user.email team@jellyfin.org
           git commit --all --amend -m "Update OpenAPI to unstable"
 
       - name: Push changes


### PR DESCRIPTION
Should fix the latest unstable workflow error: https://github.com/jellyfin/jellyfin-sdk-typescript/actions/runs/9747998495/job/26901985693