### PR TITLE
Allow specifying https default port 443

### DIFF
--- a/src/utils/__tests__/address-candidates.test.ts
+++ b/src/utils/__tests__/address-candidates.test.ts
@@ -39,6 +39,12 @@ describe('Address Candidates', () => {
 			expect(candidates[1]).toBe('http://example.com:8888/');
 		});
 
+		it('should return one candidate for an https url with the default port specified', () => {
+			const candidates = getAddressCandidates('https://example.com:443');
+			expect(candidates).toHaveLength(1);
+			expect(candidates[0]).toBe('https://example.com/');
+		});
+
 		it('should return an empty list for urls with non http(s) protocols', () => {
 			const candidates = getAddressCandidates('ftp://example.com');
 			expect(candidates).toHaveLength(0);

--- a/src/utils/address-candidates.ts
+++ b/src/utils/address-candidates.ts
@@ -56,6 +56,7 @@ export function getAddressCandidates(input: string): Array<string> {
 		const url = parseUrl(input);
 		candidates.push(url);
 
+
 		if (url.protocol === HTTP_PROTOCOL) {
 			const copy = copyUrl(url);
 			copy.protocol = HTTPS_PROTOCOL;
@@ -81,7 +82,12 @@ export function getAddressCandidates(input: string): Array<string> {
 
 		return candidates
 			.sort((a, b) => getScore(b) - getScore(a))
-			.map(candidate => candidate.toString());
+			.map(candidate => {
+				if (candidate.port === '0') {
+					candidate.port = '';
+				}
+				return candidate.toString();
+			});
 	} catch (err) {
 		console.warn(err);
 		return [];

--- a/src/utils/url/normalize-url.ts
+++ b/src/utils/url/normalize-url.ts
@@ -52,6 +52,12 @@ export default function normalizeUrl(urlString: string): string {
 
 	const urlObject = new URL(urlString);
 
+	// Set port to 0 if the URL specifies the default port for HTTPS (443)
+	// This ensures that the URL class doesn't remove it, allowing for later manipulation in server discovery.
+	if (!urlObject.port && urlObject.protocol === 'https:' && urlString.match(/:443/)) {
+		urlObject.port = '0';
+	}
+
 	// Remove hash
 	urlObject.hash = '';
 


### PR DESCRIPTION
When specifying port 443 to the URL class, it is removed per the specs.

![image](https://github.com/jellyfin/jellyfin-sdk-typescript/assets/66485277/9d2eba2d-6752-4e82-a204-a8887f8b7048)

However, I would like to force port 443 and not have others candidates slowing down the discovery.
We can achieve this behavior by temporarily setting the url port to 0.

I also added testing.
