### PR TITLE
Log patch status for unstable branch CI

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Commit changes
         continue-on-error: true
         run: |
-          ! git diff --exit-code --no-patch
+          ! git diff --exit-code
           git commit --all --amend -m "Update OpenAPI to unstable"
 
       - name: Push changes


### PR DESCRIPTION
Include patch status in logs for unstable branch CI for debugging nightly builds