### PR TITLE
Use url exclusively when protocol & port specified

### DIFF
--- a/src/utils/__tests__/address-candidates.test.ts
+++ b/src/utils/__tests__/address-candidates.test.ts
@@ -33,10 +33,24 @@ describe('Address Candidates', () => {
 		});
 
 		it('should use the specified port when provided', () => {
-			const candidates = getAddressCandidates('http://example.com:8888');
+			const candidates = getAddressCandidates('example.com:8888');
 			expect(candidates).toHaveLength(2);
 			expect(candidates[0]).toBe('https://example.com:8888/');
 			expect(candidates[1]).toBe('http://example.com:8888/');
+		});
+
+		it('should return a single candidate when protocol and port are specified', () => {
+			let candidates = getAddressCandidates('https://example.com:443');
+			expect(candidates).toHaveLength(1);
+			expect(candidates[0]).toBe('https://example.com/');
+
+			candidates = getAddressCandidates('http://example.com:80');
+			expect(candidates).toHaveLength(1);
+			expect(candidates[0]).toBe('http://example.com/');
+
+			candidates = getAddressCandidates('http://example.com:8096');
+			expect(candidates).toHaveLength(1);
+			expect(candidates[0]).toBe('http://example.com:8096/');
 		});
 
 		it('should return an empty list for urls with non http(s) protocols', () => {

--- a/src/utils/url/__tests__/url.test.ts
+++ b/src/utils/url/__tests__/url.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl } from '..';
+import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl, hasProtocolAndPort } from '..';
 
 /**
  * Url tests.
@@ -37,6 +37,26 @@ describe('Url', () => {
 			expect(() => {
 				getDefaultPort('FOO');
 			}).toThrow();
+		});
+	});
+
+	describe('hasProtocolAndPort()', () => {
+		it('should return true if the protocol and port are specified', () => {
+			const urlString = 'https://example.com:443';
+			const url = parseUrl(urlString);
+			expect(hasProtocolAndPort(urlString, url)).toBe(true);
+		});
+
+		it('should return false if the port is not specified', () => {
+			const urlString = 'https://example.com';
+			const url = parseUrl(urlString);
+			expect(hasProtocolAndPort(urlString, url)).toBe(false);
+		});
+
+		it('should return false if the protocol is not specified', () => {
+			const urlString = 'example.com:443';
+			const url = parseUrl(urlString);
+			expect(hasProtocolAndPort(urlString, url)).toBe(false);
 		});
 	});
 

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -31,6 +31,20 @@ export function getDefaultPort(protocol: string): number {
 }
 
 /**
+ * Checks if the url string specifies the protocol and port.
+ * @param urlString The url string to test.
+ * @param url The parsed url object.
+ * @returns True if the the url string includes the protocol and port.
+ */
+export function hasProtocolAndPort(urlString: string, url: URL): boolean {
+	// The parsed URL object drops the default port
+	const port = url.port || getDefaultPort(url.protocol);
+	return urlString
+		.toLowerCase()
+		.startsWith(`${url.protocol}//${url.hostname.toLowerCase()}:${port}`);
+}
+
+/**
  * Parses a string to a Url object.
  * @param input A string representing a url.
  * @returns The Url object.


### PR DESCRIPTION
* Updates `getAddressCandidates()` to only return the parsed input url if the protocol and port were specified.
* Adds comments and fixes a sonar code smell (`sort()` being used misleadingly).