### PR TITLE
Add isDefaultPort utility

### DIFF
--- a/src/utils/address-candidates.ts
+++ b/src/utils/address-candidates.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { HTTPS_PORT, HTTP_PORT, HTTP_PROTOCOL, HTTPS_PROTOCOL, parseUrl, copyUrl, getDefaultPort, hasProtocolAndPort } from './url';
+import { HTTP_PROTOCOL, HTTPS_PROTOCOL, parseUrl, copyUrl, hasProtocolAndPort, isDefaultPort } from './url';
 
 /** The default http port for Jellyfin servers. */
 export const JF_HTTP_PORT = 8096;
@@ -34,9 +34,7 @@ function getScore(url: URL): number {
 	}
 
 	// Prefer default ports for http(s) protocols
-	if (url.protocol === HTTPS_PROTOCOL && (!url.port || url.port === HTTPS_PORT.toString())) {
-		score += 3;
-	} else if (url.protocol === HTTP_PROTOCOL && (!url.port || url.port === HTTP_PORT.toString())) {
+	if (isDefaultPort(url)) {
 		score += 3;
 	}
 
@@ -72,7 +70,7 @@ export function getAddressCandidates(input: string): Array<string> {
 
 		// Add candidates with JF default ports for candidates using the protocol default port
 		candidates
-			.filter(val => !val.port || val.port === getDefaultPort(val.protocol).toString())
+			.filter(isDefaultPort)
 			.forEach(val => {
 				if (val.protocol === HTTP_PROTOCOL) {
 					const copy = copyUrl(val);

--- a/src/utils/url/__tests__/url.test.ts
+++ b/src/utils/url/__tests__/url.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl, hasProtocolAndPort } from '..';
+import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl, hasProtocolAndPort, isDefaultPort } from '..';
 
 /**
  * Url tests.
@@ -57,6 +57,25 @@ describe('Url', () => {
 			const urlString = 'example.com:443';
 			const url = parseUrl(urlString);
 			expect(hasProtocolAndPort(urlString, url)).toBe(false);
+		});
+	});
+
+	describe('isDefaultPort()', () => {
+		it('should return true for default port', () => {
+			let url = new URL('https://example.com');
+			expect(isDefaultPort(url)).toBe(true);
+
+			url.port = HTTPS_PORT.toString();
+			expect(isDefaultPort(url)).toBe(true);
+
+			url = new URL('http://example.com');
+			url.port = HTTP_PORT.toString();
+			expect(isDefaultPort(url)).toBe(true);
+		});
+
+		it('should return false for alternate ports', () => {
+			const url = new URL('http://example.com:8888');
+			expect(isDefaultPort(url)).toBe(false);
 		});
 	});
 

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -31,10 +31,10 @@ export function getDefaultPort(protocol: string): number {
 }
 
 /**
- * Checks if the url string specifies the protocol and port.
- * @param urlString The url string to test.
- * @param url The parsed url object.
- * @returns True if the the url string includes the protocol and port.
+ * Checks if the URL string specifies the protocol and port.
+ * @param urlString The URL string to test.
+ * @param url The parsed URL object.
+ * @returns True if the the URL string includes the protocol and port.
  */
 export function hasProtocolAndPort(urlString: string, url: URL): boolean {
 	// The parsed URL object drops the default port
@@ -45,9 +45,19 @@ export function hasProtocolAndPort(urlString: string, url: URL): boolean {
 }
 
 /**
- * Parses a string to a Url object.
- * @param input A string representing a url.
- * @returns The Url object.
+ * Checks if the URL is using the protocol's default port.
+ * @param url The URL object to check.
+ * @returns True if the URL port is the protocol default.
+ */
+export function isDefaultPort(url: URL): boolean {
+	return !url.port
+		|| (url.port === getDefaultPort(url.protocol).toString());
+}
+
+/**
+ * Parses a string to a URL object.
+ * @param input A string representing a URL.
+ * @returns The URL object.
  */
 export function parseUrl(input: string): URL {
 	if (!input?.trim()) {


### PR DESCRIPTION
Adds a new utility function to check if a URL is using the default port. This fixes a code maintainability issue in sonar and simplifies the code a bit.