### PR TITLE
Remove addPlayedIndicator from ImageRequestParameters

### DIFF
--- a/src/models/api/image-request-parameters.ts
+++ b/src/models/api/image-request-parameters.ts
@@ -21,7 +21,6 @@ export interface ImageRequestParameters {
 	tag?: string,
 	cropWhitespace?: boolean,
 	format?: ImageFormat,
-	addPlayedIndicator?: boolean,
 	percentPlayed?: number,
 	unplayedCount?: number,
 	blur?: number,


### PR DESCRIPTION
This property was removed in Jellyfin 10.9.0.

https://github.com/jellyfin/jellyfin/pull/9186