### PR TITLE
Add api method for getting a uri

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -80,4 +80,10 @@ describe('Api', () => {
 		const api = new Api(SERVER_URL, TEST_CLIENT, TEST_DEVICE);
 		expect(api.basePath).toBe(SERVER_URL);
 	});
+
+	it('should return the correct uri', () => {
+		const api = new Api(SERVER_URL, TEST_CLIENT, TEST_DEVICE);
+		const uri = api.getUri('/api/url', { param1: 'bar', param2: 'baz 123;xyz' });
+		expect(uri).toBe(`${SERVER_URL}/api/url?param1=bar&param2=baz+123%3Bxyz`);
+	});
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,6 +65,20 @@ export class Api {
 	}
 
 	/**
+	 * Gets a full URI for a relative URL to the Jellyfin server for a given SDK Api instance.
+	 * @param url The relative URL.
+	 * @param params Any URL parameters.
+	 * @returns The complete URI with protocol, host, and base URL (if any).
+	 */
+	getUri(url: string, params?: object) {
+		return this.axiosInstance.getUri({
+			baseURL: this.basePath,
+			url,
+			params
+		});
+	}
+
+	/**
 	 * Convenience method for logging out and updating the internal state.
 	 */
 	logout(): Promise<AxiosResponse<never> | AxiosResponse<void>> {


### PR DESCRIPTION
Adds a utility method for getting a uri to the Api class.

Upstreams this function from web: https://github.com/jellyfin/jellyfin-web/blob/master/src/utils/api.ts