### PR TITLE
Update authentication accessToken handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+* Ensure `Authorization` header is sent for all requests ([#948](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/948)).
+
+### Deprecated
+
+* Deprecate authentication helper methods in `Api` class ([#949](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/948)). Updating the `accessToken` is now handled transparently.
+
 ## [0.12.0] - 2025-10-21
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Deprecated
 
-* Deprecate authentication helper methods in `Api` class ([#949](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/948)). Updating the `accessToken` is now handled transparently.
+* Deprecate authentication helper methods in `Api` class ([#949](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/948)).
+  Updating the `accessToken` is now handled transparently in `getUserApi` and `getSessionApi`. If you need to handle
+  authentication manually, then you should manually create `UserApi` and `SessionApi` instances.
 
 ## [0.12.0] - 2025-10-21
 
 ### Security
 
-* Bumped axios peer dependency version ([#939](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/939)). Note that this axios vulnerability only affected applications running in node.js.
+* Bumped axios peer dependency version ([#939](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/939)).
+  Note that this axios vulnerability only affected applications running in node.js.
 
 ### Added
 
@@ -89,7 +92,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * API classes are no longer exposed via getters.
   Instead you need to call a function passing the `Api` instance as a parameter.
   For example: `getSystemApi(api)`.
-  While I do feel this is a slightly worse developer experience, it was a necessary change to support tree-shaking ([#149](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/149)).
+  While I do feel this is a slightly worse developer experience, it was a necessary change to support tree-shaking
+  ([#149](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/149)).
 * `BaseItemKind` is now included in the generated client.
   Imports will need updated ([#187](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/187)).
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -10,6 +10,7 @@ import { TEST_CLIENT, TEST_DEVICE } from '../__helpers__/common';
 
 import { Jellyfin } from '../jellyfin';
 import { RecommendedServerInfoScore } from '../models/recommended-server-info';
+import { getSessionApi } from '../utils/api/session-api';
 import { getSystemApi } from '../utils/api/system-api';
 import { getUserApi } from '../utils/api/user-api';
 import { getUserViewsApi } from '../utils/api/user-views-api';
@@ -70,11 +71,14 @@ describe('Test the Base SDK', () => {
 		});
 		const api = jellyfin.createApi(SERVER_URL);
 
-		const auth = await api.authenticateUserByName(USERNAME, PASSWORD);
+		const auth = await getUserApi(api)
+			.authenticateUserByName({ authenticateUserByName: { Username: USERNAME, Pw: PASSWORD } });
 		// console.log('Auth =>', auth.data);
 		expect(auth.data).toBeTruthy();
+		expect(api.accessToken).not.toBe('');
 
-		await api.logout();
+		await getSessionApi(api).reportSessionEnded();
+		expect(api.accessToken).toBe('');
 	});
 
 	it('user views api', async () => {
@@ -84,12 +88,13 @@ describe('Test the Base SDK', () => {
 		});
 		const api = jellyfin.createApi(SERVER_URL);
 
-		await api.authenticateUserByName(USERNAME, PASSWORD);
+		await getUserApi(api)
+			.authenticateUserByName({ authenticateUserByName: { Username: USERNAME, Pw: PASSWORD } });
 
 		const views = await getUserViewsApi(api).getUserViews();
 		// console.log('User Views =>', views.data);
 		expect(views.data).toBeTruthy();
 
-		await api.logout();
+		await getSessionApi(api).reportSessionEnded();
 	});
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,7 +51,8 @@ export class Api {
 	}
 
 	/**
-	 * Convenience method for authenticating a user by name and updating the internal state.
+	 * Convenience method for authenticating a user by name.
+	 * @deprecated Use `getUserApi().authenticateUserByName()` instead.
 	 * @param username The username.
 	 * @param password The user password if required.
 	 */
@@ -59,11 +60,7 @@ export class Api {
 		return getUserApi(this).authenticateUserByName(
 			// The axios client does some strange wrapping of the param object
 			{ authenticateUserByName: { Username: username, Pw: password } }
-		).then(response => {
-			// Update the current token and configuration object
-			this.accessToken = response.data.AccessToken || '';
-			return response;
-		});
+		);
 	}
 
 	/**
@@ -81,13 +78,11 @@ export class Api {
 	}
 
 	/**
-	 * Convenience method for logging out and updating the internal state.
+	 * Convenience method for logging out.
+	 * @deprecated Use `getSessionApi().reportSessionEnded()` instead.
 	 */
 	logout(): Promise<AxiosResponse<never> | AxiosResponse<void>> {
-		return getSessionApi(this).reportSessionEnded().then(response => {
-			this.accessToken = '';
-			return response;
-		});
+		return getSessionApi(this).reportSessionEnded();
 	}
 
 	get authorizationHeader(): string {

--- a/src/utils/api/session-api.ts
+++ b/src/utils/api/session-api.ts
@@ -4,9 +4,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import type { RawAxiosRequestConfig, AxiosResponse } from 'axios';
+
 import type { Api } from '../../api';
 import { SessionApi } from '../../generated-client/api/session-api';
 
+/** An augmented SessionApi that updates the state of the access token in the Api instance. */
+class AugmentedSessionApi extends SessionApi {
+	api: Api;
+
+	constructor(api: Api) {
+		super(api.configuration, undefined, api.axiosInstance);
+		this.api = api;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
+	public reportSessionEnded(options?: RawAxiosRequestConfig): Promise<AxiosResponse<void, any, {}>> {
+		return super.reportSessionEnded(options)
+			.then(response => {
+				this.api.accessToken = '';
+				return response;
+			});
+	}
+}
+
 export function getSessionApi(api: Api): SessionApi {
-	return new SessionApi(api.configuration, undefined, api.axiosInstance);
+	return new AugmentedSessionApi(api);
 }

--- a/src/utils/api/user-api.ts
+++ b/src/utils/api/user-api.ts
@@ -4,9 +4,47 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import type { RawAxiosRequestConfig, AxiosResponse } from 'axios';
+
 import type { Api } from '../../api';
+import type { UserApiAuthenticateUserByNameRequest, UserApiAuthenticateWithQuickConnectRequest } from '../../generated-client/api/user-api';
 import { UserApi } from '../../generated-client/api/user-api';
+import type { AuthenticationResult } from '../../generated-client/models/authentication-result';
+
+/** An augmented UserApi that updates the state of the access token in the Api instance. */
+class AugmentedUserApi extends UserApi {
+	api: Api;
+
+	constructor(api: Api) {
+		super(api.configuration, undefined, api.axiosInstance);
+		this.api = api;
+	}
+
+	public authenticateUserByName(
+		requestParameters: UserApiAuthenticateUserByNameRequest,
+		options?: RawAxiosRequestConfig
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
+	): Promise<AxiosResponse<AuthenticationResult, any, {}>> {
+		return super.authenticateUserByName(requestParameters, options)
+			.then(response => {
+				this.api.accessToken = response.data.AccessToken || '';
+				return response;
+			});
+	}
+
+	public authenticateWithQuickConnect(
+		requestParameters: UserApiAuthenticateWithQuickConnectRequest,
+		options?: RawAxiosRequestConfig
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
+	): Promise<AxiosResponse<AuthenticationResult, any, {}>> {
+		return super.authenticateWithQuickConnect(requestParameters, options)
+			.then(response => {
+				this.api.accessToken = response.data.AccessToken || '';
+				return response;
+			});
+	}
+}
 
 export function getUserApi(api: Api): UserApi {
-	return new UserApi(api.configuration, undefined, api.axiosInstance);
+	return new AugmentedUserApi(api);
 }


### PR DESCRIPTION
* Updates the `accessToken` handling during authentication/logout to not require calling the helper methods in the `Api` class.
* Deprecates the helper methods.

Depends on #948 