### PR TITLE
Cleanup unused codecov config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,7 +18,6 @@ openapi-templates
 
 .eslintignore
 .eslintrc.cjs
-codecov.yml
 vitest.config.ts
 rollup.config.js
 sonar-project.properties

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,0 @@
-
-coverage:
-  range: 70...90
-  status:
-    project:
-      default:
-        threshold: 1%
-        if_not_found: success # no commit found? still set a success
-    patch: off


### PR DESCRIPTION
We've been using sonarqube for coverage reporting so any codecov config/references are obsolete