### PR TITLE
ci: use workflow_run pattern for PR workflows

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,12 +15,12 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
 
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Download source artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
+          name: source
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download coverage artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,13 @@ jobs:
         with:
           name: coverage
           path: coverage/
+          retention-days: 1
+
+      - name: Upload source artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: source
+          path: |
+            src/
+            sonar-project.properties
+          retention-days: 1


### PR DESCRIPTION
## Summary

Refactor CI workflows to use the `workflow_run` pattern for PR builds.

## Changes

- Build jobs run on `pull_request` trigger with minimal permissions
- Deploy/privileged jobs run on `workflow_run`, consuming artifacts
- No functional changes to build or deploy behavior

---

<!-- kody-pr-summary:start -->
This pull request refactors the Continuous Integration (CI) workflows to utilize a `workflow_run` pattern for improved consistency and efficiency.

Specifically, the changes include:
*   The `test.yml` workflow now uploads the project's source code (`src/` directory) and `sonar-project.properties` file as a named artifact called `source`.
*   The `sonarcloud.yml` workflow has been updated to download this `source` artifact from the triggering workflow run, rather than checking out the repository directly.

This approach ensures that the SonarCloud analysis is performed on the exact same source code snapshot that was used by the preceding workflow (e.g., the test workflow), preventing potential discrepancies.
<!-- kody-pr-summary:end -->