### PR TITLE
Add changelog entry for moved constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * `getLibraryApi` now returns an augmented class with a `getDownloadUrl` method ([#967](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/967)).
 * The `Api` class now contains a `webSocket` field, of which `OutboundWebSocketMessageType`s can be subscribed to for handling WebSocket messages ([#966](https://github.com/jellyfin/jellyfin-sdk-typescript/issues/966)).
 
+### Changed
+
+* Any usages of `AUTHORIZATION_HEADER` and `AUTHORIZATION_PARAMETER` constants must be updated to be imported from `/constants` ([#966](https://github.com/jellyfin/jellyfin-sdk-typescript/issues/966)).
+
 ## [0.13.0] - 2025-10-28
 
 ### Changed


### PR DESCRIPTION
Updates the changelog to note the breaking change for constants moving. I was going to export them in both places and mark `api` as deprecated but that is messy... and probably excessive.