### PR TITLE
Add function to prevent double encoding uri components

### DIFF
--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -5,15 +5,17 @@
  */
 import type { ClientInfo, DeviceInfo } from '../models';
 
+import { safeEncodeURIComponent } from './url';
+
 /**
  * Returns a valid authorization header string.
  */
 export function getAuthorizationHeader(clientInfo: ClientInfo, deviceInfo: DeviceInfo, accessToken = ''): string {
 	return [
-		`MediaBrowser Client="${encodeURIComponent(clientInfo.name)}"`,
-		`Device="${encodeURIComponent(deviceInfo.name)}"`,
-		`DeviceId="${encodeURIComponent(deviceInfo.id)}"`,
-		`Version="${encodeURIComponent(clientInfo.version)}"`,
-		`Token="${encodeURIComponent(accessToken)}"`
+		`MediaBrowser Client="${safeEncodeURIComponent(clientInfo.name)}"`,
+		`Device="${safeEncodeURIComponent(deviceInfo.name)}"`,
+		`DeviceId="${safeEncodeURIComponent(deviceInfo.id)}"`,
+		`Version="${safeEncodeURIComponent(clientInfo.version)}"`,
+		`Token="${safeEncodeURIComponent(accessToken)}"`
 	].join(', ');
 }

--- a/src/utils/url/__tests__/url.test.ts
+++ b/src/utils/url/__tests__/url.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl, hasProtocolAndPort, isDefaultPort, buildWebSocketUrl } from '..';
+import { getDefaultPort, HTTP_PORT, HTTPS_PORT, HTTPS_PROTOCOL, HTTP_PROTOCOL, copyUrl, parseUrl, hasProtocolAndPort, isDefaultPort, buildWebSocketUrl, safeEncodeURIComponent } from '..';
 
 /**
  * Url tests.
@@ -138,6 +138,19 @@ describe('Url', () => {
 		it('should return a URL instance', () => {
 			const url = buildWebSocketUrl('http://example.com');
 			expect(url).toBeInstanceOf(URL);
+		});
+	});
+
+	describe('safeEncodeURIComponent()', () => {
+		it('should encode reserved characters', () => {
+			const input = 'foo bar/baz?qux=quux&corge=grault';
+			const expected = 'foo%20bar%2Fbaz%3Fqux%3Dquux%26corge%3Dgrault';
+			expect(safeEncodeURIComponent(input)).toBe(expected);
+		});
+
+		it('should not double encode already encoded components', () => {
+			const input = 'foo%20bar%2Fbaz';
+			expect(safeEncodeURIComponent(input)).toBe(input);
 		});
 	});
 });

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -69,8 +69,29 @@ export function parseUrl(input: string): URL {
 	);
 }
 
+/**
+ * Builds a WebSocket URL from an HTTP/HTTPS URL.
+ * @param uri The HTTP/HTTPS URL string.
+ * @returns The WebSocket URL object.
+ */
 export function buildWebSocketUrl(uri: string): URL {
 	return new URL(
 		uri.replace(/^http/, 'ws')
 	);
+}
+
+/**
+ * Safely encodes a URL component, avoiding double encoding if the component is already encoded.
+ * @param component The URL component to encode.
+ * @returns The safely encoded URL component.
+ */
+export function safeEncodeURIComponent(component: string): string {
+	try {
+		const decoded = decodeURIComponent(component);
+		// If the decoded component is different than the original, then the original was encoded, so we return it as is.
+		if (decoded !== component) return component;
+	} catch {
+		// If decoding fails, the component is not properly encoded, so we encode it.
+	}
+	return encodeURIComponent(component);
 }


### PR DESCRIPTION
Adds a utility function to safely encode URI components to use for the authorization header.

This is useful in case clients encode values before they are passed to the SDK.