### PR TITLE
Add export API

### DIFF
--- a/src/utils/api/library-api.ts
+++ b/src/utils/api/library-api.ts
@@ -28,6 +28,18 @@ class AugmentedLibraryApi extends LibraryApi {
 			{ [AUTHORIZATION_PARAMETER]: this.api.accessToken }
 		);
 	}
+
+	/**
+	 * Get an Item export URL.
+	 * @param requestParameters The export request parameters.
+	 * @returns The Item export URL.
+	 */
+	public getExportUrl(requestParameters: LibraryApiGetExportRequest): string {
+		return this.api.getUri(
+			`/Items/${requestParameters.itemId}/Export`,
+			{ [AUTHORIZATION_PARAMETER]: this.api.accessToken }
+		);
+	}
 }
 
 export function getLibraryApi(api: Api): AugmentedLibraryApi {


### PR DESCRIPTION
This adds a getExportUrl function which is an export equivalent of getDownloadUrl which uses `/Items/${requestParameters.itemId}/Export` instead of `/Items/${requestParameters.itemId}/Download`.

Related to: https://github.com/jellyfin/jellyfin/pull/13857