### PR TITLE
Update the unstable openapi workflow to only push updates on changes

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -2,7 +2,7 @@ name: SDK Unstable Branch
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: "0 5 * * *"
   workflow_dispatch:
   push:
     branches:
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config user.name jellyfin-bot
           git config user.email team@jellyfin.org
-          git rebase --strategy-option theirs origin/master
+          git checkout -b openapi-unstable-tmp --no-track origin/master
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -62,4 +62,5 @@ jobs:
           [[ -n $(git status --porcelain) ]] && git add --all && git commit --amend -m "Update OpenAPI to unstable"
 
       - name: Push changes
-        run: git push --force origin openapi-unstable
+        run: |
+          git diff --quiet openapi-unstable openapi-unstable-tmp || git push --force origin openapi-unstable-tmp:openapi-unstable


### PR DESCRIPTION
Updates the unstable openapi workflow to always start by creating a new branch from master and only pushing to the `openapi-unstable` branch if there are changes... hopefully

Fixes builds failing when there are conflicts in the generated client between master and unstable branches: https://github.com/jellyfin/jellyfin-sdk-typescript/actions/runs/28885374326/job/85684088926