### PR TITLE
Remove amend when committing unstable api changes

### DIFF
--- a/.github/workflows/sdk-unstable-branch.yaml
+++ b/.github/workflows/sdk-unstable-branch.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Commit changes
         continue-on-error: true
         run: |
-          [[ -n $(git status --porcelain) ]] && git add --all && git commit --amend -m "Update OpenAPI to unstable"
+          [[ -n $(git status --porcelain) ]] && git add --all && git commit -m "Update OpenAPI to unstable"
 
       - name: Push changes
         run: |


### PR DESCRIPTION
Since the workflow is creating a new branch from master, we shouldn't be amending the commit now :upside_down_face: 