### PR TITLE
Support API language via DeviceInfo

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -155,8 +155,7 @@ export class Api {
 
 	get acceptLanguageHeader(): string | undefined {
 		const languages = this._deviceInfo.languages;
-		if (!languages || !languages.length) return undefined;
-		return languages.join(',');
+		if (languages?.length) return languages.join(',');
 	}
 
 	subscribe<T extends OutboundWebSocketMessageType>(messageTypes: T[], onMessage: SocketMessageHandler<T>) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,7 +6,7 @@
 import type { AxiosInstance, AxiosResponse } from 'axios';
 import globalInstance from 'axios';
 
-import { AUTHORIZATION_HEADER, AUTHORIZATION_PARAMETER } from './constants';
+import { ACCEPT_LANGUAGE_HEADER, AUTHORIZATION_HEADER, AUTHORIZATION_PARAMETER } from './constants';
 import { Configuration } from './generated-client/configuration';
 import type { AuthenticationResult } from './generated-client/models/authentication-result';
 import type { ClientInfo, DeviceInfo } from './models';
@@ -64,7 +64,8 @@ export class Api {
 			basePath: this._basePath,
 			baseOptions: {
 				headers: {
-					[AUTHORIZATION_HEADER]: this.authorizationHeader
+					[AUTHORIZATION_HEADER]: this.authorizationHeader,
+					[ACCEPT_LANGUAGE_HEADER]: this.acceptLanguageHeader
 				}
 			}
 		});
@@ -150,6 +151,12 @@ export class Api {
 
 	get authorizationHeader(): string {
 		return getAuthorizationHeader(this._clientInfo, this._deviceInfo, this._accessToken);
+	}
+
+	get acceptLanguageHeader(): string | undefined {
+		const languages = this._deviceInfo.languages;
+		if (!languages || !languages.length) return undefined;
+		return languages.join(',');
 	}
 
 	subscribe<T extends OutboundWebSocketMessageType>(messageTypes: T[], onMessage: SocketMessageHandler<T>) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -155,7 +155,7 @@ export class Api {
 
 	get acceptLanguageHeader(): string | undefined {
 		const languages = this._deviceInfo.languages;
-		if (languages?.length) return languages.join(',');
+		return languages?.length ? languages.join(',') : undefined;
 	}
 
 	subscribe<T extends OutboundWebSocketMessageType>(messageTypes: T[], onMessage: SocketMessageHandler<T>) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,5 +7,8 @@
 /** The authorization header field name. */
 export const AUTHORIZATION_HEADER = 'Authorization';
 
+/** The accept language header field name. */
+export const ACCEPT_LANGUAGE_HEADER = 'Accept-Language';
+
 /** The authorization query parameter name. */
 export const AUTHORIZATION_PARAMETER = 'ApiKey';

--- a/src/models/device-info.ts
+++ b/src/models/device-info.ts
@@ -10,4 +10,5 @@
 export interface DeviceInfo {
 	id: string,
 	name: string
+	languages?: string[];
 }


### PR DESCRIPTION
Implement support for jellyfin/jellyfin-meta#107 / jellyfin/jellyfin#16488 by adding a new "languages" list to the DeviceInfo. The Api class uses this information to set the `Accept-Language` header for API requests.

Similar to https://github.com/jellyfin/jellyfin-sdk-kotlin/pull/1210