### PR TITLE
Add compareVersions and getDisplayVersion utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * `getLibraryApi` now returns an augmented class with a `getDownloadUrl` method ([#967](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/967)).
 * The `Api` class now contains a `webSocket` field, of which `OutboundWebSocketMessageType`s can be subscribed to for handling WebSocket messages ([#966](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/968)).
 * Added support for sending `Accept-Language` header with requests by including `languages` in `DeviceInfo` ([#1076](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1076)).
+* Added `compareVersions` and `getDisplayVersion` utility functions for comparing and formatting versions ([#1083](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1083)).
 
 ### Changed
 
@@ -20,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Update OpenAPI spec for Jellyfin 12.0 ([#1071](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1071)).
   Note that **A LOT** of the APIs were renamed or moved as part of this update.
   Specific changes can be found in [#1072](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1072).
+
+### Deprecated
+
+* `isVersionLess` is deprecated in favor of `compareVersions` ([#1083](https://github.com/jellyfin/jellyfin-sdk-typescript/pull/1083)).
 
 ## [0.13.0] - 2025-10-28
 

--- a/src/utils/__tests__/versioning.test.ts
+++ b/src/utils/__tests__/versioning.test.ts
@@ -5,84 +5,48 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { isVersionLess } from '..';
+import { compareVersions, getDisplayVersion } from '..';
 
 /**
  * Versioning tests
  *
  * @group unit/utils
  */
-describe('Versioning checks', () => {
-	it("doesn't allow versions with negative numbers", () => {
-		expect(() => isVersionLess('-10.5.3', '10.8.-9')).toThrow(TypeError);
+describe('compareVersions', () => {
+	it('should return 0 for equal versions', () => {
+		expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
 	});
-	it("doesn't allow versions with non-numeric characters", () => {
-		expect(() => isVersionLess('10.2.7-beta', '15.8.9')).toThrow(TypeError);
+
+	it('should return -1 when the first version is lower', () => {
+		expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
+		expect(compareVersions('1.2.3', '1.3.0')).toBe(-1);
+		expect(compareVersions('1.2.3', '2')).toBe(-1);
 	});
-	/**
-     * Equal
-     */
-	it('false on equal version: 0.0.0', () => {
-		expect(isVersionLess('0.0.0', '0.0.0')).toBe(false);
+
+	it('should return 1 when the first version is higher', () => {
+		expect(compareVersions('1.2.4', '1.2.3')).toBe(1);
+		expect(compareVersions('1.3.0', '1.2.3')).toBe(1);
+		expect(compareVersions('2', '1.2.3')).toBe(1);
 	});
-	it('false on equal version: 0.0.5', () => {
-		expect(isVersionLess('0.0.5', '0.0.5')).toBe(false);
+});
+
+describe('getDisplayVersion', () => {
+	it('should return undefined for null or undefined input', () => {
+		expect(getDisplayVersion(null)).toBeUndefined();
+		expect(getDisplayVersion(undefined)).toBeUndefined();
 	});
-	it('false on equal version: 0.5.0', () => {
-		expect(isVersionLess('0.5.0', '0.5.0')).toBe(false);
+
+	it('should return the full version for versions below 11.0.0', () => {
+		expect(getDisplayVersion('10.11.6')).toBe('10.11.6');
 	});
-	it('false on equal version: 5.0.0', () => {
-		expect(isVersionLess('5.0.0', '5.0.0')).toBe(false);
+
+	it('should return only major.minor for versions above 10.0.0', () => {
+		expect(getDisplayVersion('11.0.0')).toBe('11.0');
+		expect(getDisplayVersion('12.3.0')).toBe('12.3');
 	});
-	it('false on equal version: 10.8.9', () => {
-		expect(isVersionLess('10.8.9', '10.8.9')).toBe(false);
-	});
-	/**
-     * Greater
-     */
-	it('1.0.0 is greater than 0.0.7', () => {
-		expect(isVersionLess('1.0.0', '0.0.7')).toBe(false);
-	});
-	it('1.0.0 is greater than 0.5.0', () => {
-		expect(isVersionLess('1.0.0', '0.5.0')).toBe(false);
-	});
-	it('1.0.0 is greater than 0.5.7', () => {
-		expect(isVersionLess('1.0.0', '0.5.7')).toBe(false);
-	});
-	it('2.0.0 is greater than 1.0.0', () => {
-		expect(isVersionLess('2.0.0', '1.0.0')).toBe(false);
-	});
-	it('0.5.0 is greater than 0.0.7', () => {
-		expect(isVersionLess('0.5.0', '0.0.7')).toBe(false);
-	});
-	it('0.5.7 is greater than 0.0.7', () => {
-		expect(isVersionLess('0.5.7', '0.0.7')).toBe(false);
-	});
-	it('2-digit versions: 12.25.34 is greater than 12.17.89', () => {
-		expect(isVersionLess('12.25.34', '12.17.89')).toBe(false);
-	});
-	/**
-     * Less
-     */
-	it('0.0.7 is less than 1.0.0', () => {
-		expect(isVersionLess('0.0.7', '1.0.0')).toBe(true);
-	});
-	it('0.5.0 is less than 1.0.0', () => {
-		expect(isVersionLess('0.5.0', '1.0.0')).toBe(true);
-	});
-	it('0.5.7 is less than 1.0.0', () => {
-		expect(isVersionLess('0.5.7', '1.0.0')).toBe(true);
-	});
-	it('1.0.0 is less than 2.0.0', () => {
-		expect(isVersionLess('1.0.0', '2.0.0')).toBe(true);
-	});
-	it('0.0.7 is less than 0.5.0', () => {
-		expect(isVersionLess('0.0.7', '0.5.0')).toBe(true);
-	});
-	it('0.0.7 is less than 0.5.7', () => {
-		expect(isVersionLess('0.0.7', '0.5.7')).toBe(true);
-	});
-	it('2-digit versions: 12.17.89 is less than 12.25.34', () => {
-		expect(isVersionLess('12.17.89', '12.25.34')).toBe(true);
+
+	it('should return the full version if there is a non-zero patch version above 10.0.0', () => {
+		expect(getDisplayVersion('11.0.1')).toBe('11.0.1');
+		expect(getDisplayVersion('12.3.4')).toBe('12.3.4');
 	});
 });

--- a/src/utils/versioning.ts
+++ b/src/utils/versioning.ts
@@ -1,37 +1,71 @@
 /**
- * @returns - Array of 3 numbers or undefined
+ * @returns - Array of numbers or undefined
  * (if the passed string it's not in the MAJOR.MINOR.PATCH numeric-only format)
  */
 function parseVersion(version: string): number[] | undefined {
 	const arr = version.split('.').map(Number);
 
-	if (arr.length === 3 && arr.every((n) => n >= 0)) {
+	if (arr.length && arr.every((n) => n >= 0)) {
 		return arr;
 	}
 }
 
 /**
+ * Compares two version strings (e.g., "1.2.3") and returns:
+ * -1 if a < b
+ * 1 if a > b
+ * 0 if a == b
+ *
+ * @throws If version is not in a numeric-only semver format
+ */
+export function compareVersions(a: string = '', b: string = '') {
+	const aParts = parseVersion(a);
+	const bParts = parseVersion(b);
+
+	if (!aParts || !bParts) {
+		throw new TypeError("Version doesn't match a numeric-only semver format");
+	}
+
+	for (let i = 0, length = Math.max(aParts.length, bParts.length); i < length; i++) {
+		const aVal = aParts[i] || 0;
+		const bVal = bParts[i] || 0;
+
+		if (aVal < bVal) {
+			return -1;
+		}
+
+		if (aVal > bVal) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/**
  * Check if given version is less than a baseline
  *
- * Versions must be in semver format: X.Y.Z (Major.Minor.Patch)
+ * @deprecated Use {@link compareVersions} instead
  * @throws If version is not in a numeric-only semver format
  * @param check - The version to check
  * @param baseline - The minimum version considered supported
  */
 export function isVersionLess(check: string, baseline: string): boolean {
-	const parsedCheck = parseVersion(check);
-	const parsedBaseline = parseVersion(baseline);
+	return compareVersions(check, baseline) < 0;
+}
 
-	if (!parsedCheck || !parsedBaseline) {
-		throw new TypeError("Version doesn't match a numeric-only semver format");
+/** Formats a version (e.g., "1.2.3") string for display. */
+export function getDisplayVersion(version: string | null | undefined) {
+	if (!version) return;
+
+	// For versions above 10.X, we switch to only showing MAJOR.MINOR to reflect the new versioning scheme.
+	const parts = parseVersion(version);
+	if (parts && compareVersions(version, '11') >= 0) {
+		// Just in case we have a patch version that isn't 0, we want to show it. This should not happen.
+		if (parts.length === 3 && parts[2] !== 0) return version;
+
+		return parts.slice(0, 2).join('.');
 	}
 
-	const [majorCheck, minorCheck, patchCheck] = parsedCheck;
-	const [majorBaseline, minorBaseline, patchBaseline] = parsedBaseline;
-
-	return (
-		majorCheck < majorBaseline ||
-		(majorCheck === majorBaseline && minorCheck < minorBaseline) ||
-		(majorCheck === majorBaseline && minorCheck === minorBaseline && patchCheck < patchBaseline)
-	);
+	return version;
 }


### PR DESCRIPTION
This is essentially moving utilities from web here. It is common for clients to display the server version, so it makes sense to have the utility to properly do so live here.