### PR TITLE
Fix ForceKeepAlive handling

### DIFF
--- a/src/websocket/__tests__/websocket-service.test.ts
+++ b/src/websocket/__tests__/websocket-service.test.ts
@@ -385,31 +385,36 @@ describe('WebSocketService', () => {
 	});
 
 	describe('forceKeepAlive message handling', () => {
-		it('should handle ForceKeepAlive message and schedule KeepAlive response', () => {
+		const KEEP_ALIVE_MESSAGE = JSON.stringify({ MessageType: 'KeepAlive' });
+
+		it('should answer a ForceKeepAlive immediately and keep answering every half timeout', () => {
 			vi.useFakeTimers();
 			mockWebSocket.readyState = WebSocket.OPEN;
 			service.subscribe(['Sessions'], () => {});
 
 			mockWebSocket.send.mockClear();
 
-			// Simulate receiving ForceKeepAlive message with 1000ms delay
+			// The server reports its timeout in seconds
 			const forceKeepAliveMessage = {
 				MessageType: 'ForceKeepAlive',
-				Data: 5000
+				Data: 60
 			} as ForceKeepAliveMessage;
 
 			mockWebSocket.__triggerMessage(JSON.stringify(forceKeepAliveMessage));
 
-			// Verify no KeepAlive sent immediately
-			expect(mockWebSocket.send).not.toHaveBeenCalled();
+			// The server only asks for this when it has not heard from us, so answer at once
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(1);
+			expect(mockWebSocket.send).toHaveBeenCalledWith(KEEP_ALIVE_MESSAGE);
 
-			// Advance timers by the delay
-			vi.advanceTimersByTime(2500);
+			// And then every 30 seconds, well inside the 60 second timeout
+			vi.advanceTimersByTime(29_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(1);
 
-			// Verify KeepAlive message was sent
-			expect(mockWebSocket.send).toHaveBeenCalledWith(
-				JSON.stringify({ MessageType: 'KeepAlive' })
-			);
+			vi.advanceTimersByTime(1_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(2);
+
+			vi.advanceTimersByTime(30_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(3);
 
 			vi.useRealTimers();
 		});
@@ -425,7 +430,7 @@ describe('WebSocketService', () => {
 			// Simulate receiving ForceKeepAlive message
 			const forceKeepAliveMessage = {
 				MessageType: 'ForceKeepAlive',
-				Data: 500
+				Data: 60
 			} as ForceKeepAliveMessage;
 
 			mockWebSocket.__triggerMessage(JSON.stringify(forceKeepAliveMessage));
@@ -433,7 +438,7 @@ describe('WebSocketService', () => {
 			// Handler should not be called for ForceKeepAlive
 			expect(handler).not.toHaveBeenCalled();
 
-			vi.advanceTimersByTime(500);
+			vi.advanceTimersByTime(30_000);
 
 			// Handler still should not be called after KeepAlive is sent
 			expect(handler).not.toHaveBeenCalled();
@@ -441,66 +446,67 @@ describe('WebSocketService', () => {
 			vi.useRealTimers();
 		});
 
-		it('should replace previous ForceKeepAlive timer when a new one arrives', () => {
+		it('should replace the previous keep-alive interval when a new ForceKeepAlive arrives', () => {
 			vi.useFakeTimers();
 			mockWebSocket.readyState = WebSocket.OPEN;
 			service.subscribe(['Sessions'], () => {});
 
 			mockWebSocket.send.mockClear();
 
-			// Send first ForceKeepAlive with 1000ms delay
+			// A 60 second timeout, so a keep-alive every 30 seconds
 			mockWebSocket.__triggerMessage(
 				JSON.stringify({
 					MessageType: 'ForceKeepAlive',
-					Data: 1000
+					Data: 60
 				} as ForceKeepAliveMessage)
 			);
-
-			// Advance 500ms (halfway through our threshold)
-			vi.advanceTimersByTime(200);
-
-			// Send another ForceKeepAlive with 500ms delay
-			mockWebSocket.__triggerMessage(
-				JSON.stringify({
-					MessageType: 'ForceKeepAlive',
-					Data: 500
-				} as ForceKeepAliveMessage)
-			);
-
-			// Advance 250ms more (total 450ms from start, but only 250ms from second message)
-			vi.advanceTimersByTime(250);
-
-			// Should only have sent one KeepAlive (from the second ForceKeepAlive)
 			expect(mockWebSocket.send).toHaveBeenCalledTimes(1);
-			expect(mockWebSocket.send).toHaveBeenCalledWith(
-				JSON.stringify({ MessageType: 'KeepAlive' })
+
+			vi.advanceTimersByTime(10_000);
+
+			// A 20 second timeout, so a keep-alive every 10 seconds from here on
+			mockWebSocket.__triggerMessage(
+				JSON.stringify({
+					MessageType: 'ForceKeepAlive',
+					Data: 20
+				} as ForceKeepAliveMessage)
 			);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(2);
+
+			// Only the new interval is running, the 30 second one would have fired as well
+			vi.advanceTimersByTime(10_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(3);
+
+			vi.advanceTimersByTime(10_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(4);
+
+			vi.advanceTimersByTime(10_000);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(5);
 
 			vi.useRealTimers();
 		});
 
-		it('should handle ForceKeepAlive with different delay values', () => {
+		it('should stop sending keep-alives once the socket closes', () => {
 			vi.useFakeTimers();
 			mockWebSocket.readyState = WebSocket.OPEN;
 			service.subscribe(['Sessions'], () => {});
 
 			mockWebSocket.send.mockClear();
 
-			// Test with 2000ms delay
 			mockWebSocket.__triggerMessage(
 				JSON.stringify({
 					MessageType: 'ForceKeepAlive',
-					Data: 5000
+					Data: 60
 				} as ForceKeepAliveMessage)
 			);
+			expect(mockWebSocket.send).toHaveBeenCalledTimes(1);
 
-			vi.advanceTimersByTime(1999);
+			mockWebSocket.readyState = WebSocket.CLOSED;
+			mockWebSocket.__triggerClose();
+			mockWebSocket.send.mockClear();
+
+			vi.advanceTimersByTime(120_000);
 			expect(mockWebSocket.send).not.toHaveBeenCalled();
-
-			vi.advanceTimersByTime(501);
-			expect(mockWebSocket.send).toHaveBeenCalledWith(
-				JSON.stringify({ MessageType: 'KeepAlive' })
-			);
 
 			vi.useRealTimers();
 		});

--- a/src/websocket/websocket-service.ts
+++ b/src/websocket/websocket-service.ts
@@ -33,9 +33,9 @@ export class WebSocketService {
 	private socket: WebSocket | undefined;
 
 	/**
-	 * The keep-alive timeout handle.
+	 * The keep-alive interval handle.
 	 *
-	 * Indicates when the next keep-alive message should be sent.
+	 * Sends a keep-alive message for as long as the socket is open.
 	 */
 	private keepAlive: NodeJS.Timeout | undefined;
 
@@ -128,14 +128,9 @@ export class WebSocketService {
 			const { MessageType } = data;
 
 			if (MessageType === OutboundWebSocketMessageType.ForceKeepAlive && data.Data) {
-				// Clear any existing keep-alive timeout
-				if (this.keepAlive) clearTimeout(this.keepAlive);
-
-				this.keepAlive = setTimeout(() =>
-					this.sendMessage({
-						MessageType: OutboundWebSocketMessageType.KeepAlive
-					}), data.Data / 2
-				);
+				this.clearKeepAlive();
+				this.sendKeepAlive();
+				this.keepAlive = setInterval(() => this.sendKeepAlive(), (data.Data * 1000) / 2);
 			} else {
 				const handlers = this.subscriptions.get(MessageType);
 				handlers?.forEach(handler => handler(data));
@@ -155,11 +150,9 @@ export class WebSocketService {
 			} else {
 				// Else, close and dispose
 				this.socket = undefined;
-				if (this.keepAlive) {
-					clearTimeout(this.keepAlive);
-					this.keepAlive = undefined;
-				}
 			}
+
+			this.clearKeepAlive();
 		});
 	}
 
@@ -170,6 +163,25 @@ export class WebSocketService {
 	private calculateBackoffDelay(): number {
 		const exponentialDelay = RECONNECT_INITIAL_DELAY * Math.pow(RECONNECT_DELAY_FACTOR, this.reconnectionAttempts - 1);
 		return Math.min(exponentialDelay, RECONNECT_MAX_DELAY);
+	}
+
+	/**
+	 * Sends a keep-alive message to the server.
+	 */
+	private sendKeepAlive() {
+		this.sendMessage({
+			MessageType: OutboundWebSocketMessageType.KeepAlive
+		});
+	}
+
+	/**
+	 * Stops sending keep-alive messages.
+	 */
+	private clearKeepAlive() {
+		if (this.keepAlive) {
+			clearInterval(this.keepAlive);
+			this.keepAlive = undefined;
+		}
 	}
 
 	private sendMessage(message: InboundWebSocketMessage) {
@@ -212,10 +224,7 @@ export class WebSocketService {
 			clearTimeout(this.reconnectionTimeout);
 			this.reconnectionTimeout = undefined;
 		}
-		if (this.keepAlive) {
-			clearTimeout(this.keepAlive);
-			this.keepAlive = undefined;
-		}
+		this.clearKeepAlive();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin/issues/17955

```
this.keepAlive = setTimeout(() => this.sendMessage({MessageType: KeepAlive}), data.Data / 2);
```
`Data` is the server's timeout in seconds (60), used as milliseconds, and it's a one-shot `setTimeout`. So the client answers 30 ms after each `ForceKeepAlive` and then goes permanently silent. The connection survives only on the server's own nag -> reply round trip.